### PR TITLE
feat: add interactive vintage era diagnostic flow chart

### DIFF
--- a/app/(public)/knowledge/diagnose/page.tsx
+++ b/app/(public)/knowledge/diagnose/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getFlowById } from "@/lib/diagnostic-flows";
+import { DiagnosticFlowUI } from "@/components/features/knowledge/DiagnosticFlowUI";
+
+export default function DiagnosePage() {
+  const flow = getFlowById("levis");
+
+  if (!flow) {
+    notFound();
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
+      <header className="mb-8">
+        <nav className="mb-4 text-sm text-stone-400">
+          <Link
+            href="/knowledge"
+            className="hover:text-stone-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-2 rounded"
+          >
+            古着図鑑
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-stone-600">年代判別</span>
+        </nav>
+        <h1 className="mb-1 text-2xl font-bold text-stone-900">年代判別</h1>
+        <p className="text-sm text-stone-500">
+          {flow.brand} {flow.targetItem} の年代をQ&Aで判別する
+        </p>
+      </header>
+
+      <DiagnosticFlowUI flow={flow} />
+    </main>
+  );
+}

--- a/components/features/knowledge/DiagnosticFlowUI.tsx
+++ b/components/features/knowledge/DiagnosticFlowUI.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import type {
+  DiagnosticFlow,
+  DiagnosticHistoryEntry,
+} from "@/types/diagnostic";
+import { isQuestionNode, isResultNode } from "@/types/diagnostic";
+
+interface DiagnosticFlowUIProps {
+  flow: DiagnosticFlow;
+}
+
+export function DiagnosticFlowUI({ flow }: DiagnosticFlowUIProps) {
+  const [currentNodeId, setCurrentNodeId] = useState<string>(flow.rootNodeId);
+  const [history, setHistory] = useState<DiagnosticHistoryEntry[]>([]);
+
+  const nodeMap = new Map(flow.nodes.map((n) => [n.id, n]));
+  const currentNode = nodeMap.get(currentNodeId);
+
+  function handleChoose(chosenLabel: string, nextNodeId: string) {
+    setHistory((prev) => [...prev, { nodeId: currentNodeId, chosenLabel }]);
+    setCurrentNodeId(nextNodeId);
+  }
+
+  function handleReset() {
+    setCurrentNodeId(flow.rootNodeId);
+    setHistory([]);
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 回答済み履歴 */}
+      {history.length > 0 && (
+        <ol className="space-y-2" aria-label="回答済みのステップ">
+          {history.map((entry, index) => {
+            const node = nodeMap.get(entry.nodeId);
+            const questionText =
+              node && isQuestionNode(node) ? node.question : "";
+            return (
+              <li
+                key={`${entry.nodeId}-${index}`}
+                className="rounded-lg border border-stone-200 bg-stone-100 px-4 py-3"
+              >
+                <p className="text-xs font-medium text-stone-400">
+                  ステップ {index + 1}
+                </p>
+                {questionText && (
+                  <p className="mt-0.5 text-sm text-stone-500">
+                    {questionText}
+                  </p>
+                )}
+                <p className="mt-1 text-sm font-medium text-stone-600">
+                  → {entry.chosenLabel}
+                </p>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      {/* 現在のノード */}
+      {currentNode === undefined && (
+        <p className="text-sm text-red-500">
+          ノードが見つかりません: {currentNodeId}
+        </p>
+      )}
+
+      {currentNode !== undefined && isQuestionNode(currentNode) && (
+        <div className="rounded-xl border border-stone-200 bg-stone-50 p-6">
+          <p className="mb-1 text-xs font-medium text-stone-400">
+            ステップ {history.length + 1}
+          </p>
+          <p className="mb-4 text-base font-semibold text-stone-800">
+            {currentNode.question}
+          </p>
+          <div className="space-y-2" role="group" aria-label="選択肢">
+            {currentNode.options.map((option) => (
+              <button
+                key={option.nextNodeId}
+                type="button"
+                onClick={() => handleChoose(option.label, option.nextNodeId)}
+                className="w-full rounded-lg border border-stone-300 bg-white px-4 py-3 text-left text-sm text-stone-700 transition-colors hover:bg-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-2"
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {currentNode !== undefined && isResultNode(currentNode) && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-6">
+          <p className="mb-1 text-xs font-medium text-amber-600">判定結果</p>
+          <p className="text-2xl font-bold text-amber-900">
+            {currentNode.result.era}
+          </p>
+          <p className="mt-2 text-sm text-amber-700">
+            {currentNode.result.rationale}
+          </p>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="mt-6 rounded-lg border border-stone-300 bg-white px-4 py-2 text-sm text-stone-700 transition-colors hover:bg-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-2"
+          >
+            最初から
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/diagnostic-flows/index.ts
+++ b/lib/diagnostic-flows/index.ts
@@ -1,0 +1,10 @@
+import type { DiagnosticFlow } from "@/types/diagnostic";
+import { levisFlow } from "./levis";
+
+const FLOWS: Record<string, DiagnosticFlow> = {
+  levis: levisFlow,
+};
+
+export function getFlowById(id: string): DiagnosticFlow | undefined {
+  return FLOWS[id];
+}

--- a/lib/diagnostic-flows/levis.ts
+++ b/lib/diagnostic-flows/levis.ts
@@ -1,0 +1,69 @@
+import type { DiagnosticFlow } from "@/types/diagnostic";
+
+export const levisFlow: DiagnosticFlow = {
+  id: "levis",
+  brand: "Levi's",
+  targetItem: "501",
+  rootNodeId: "root",
+  nodes: [
+    {
+      id: "root",
+      type: "question",
+      question: "タグに®マークはある？",
+      options: [
+        { label: "ある", nextNodeId: "q2" },
+        { label: "ない", nextNodeId: "q3" },
+      ],
+    },
+    {
+      id: "q2",
+      type: "question",
+      question: "タグの下部に'MADE IN U.S.A.'の記載はある？",
+      options: [
+        { label: "ある", nextNodeId: "result-a" },
+        { label: "ない", nextNodeId: "result-b" },
+      ],
+    },
+    {
+      id: "q3",
+      type: "question",
+      question: "ステッチはシングルステッチ？",
+      options: [
+        { label: "はい", nextNodeId: "result-c" },
+        { label: "いいえ", nextNodeId: "result-d" },
+      ],
+    },
+    {
+      id: "result-a",
+      type: "result",
+      result: {
+        era: "1971年〜1983年頃",
+        rationale: "®マーク＋MADE IN U.S.A.",
+      },
+    },
+    {
+      id: "result-b",
+      type: "result",
+      result: {
+        era: "1984年〜1993年頃",
+        rationale: "®マーク＋海外製",
+      },
+    },
+    {
+      id: "result-c",
+      type: "result",
+      result: {
+        era: "1955年〜1970年頃",
+        rationale: "®なし＋シングルステッチ＝初期モデル",
+      },
+    },
+    {
+      id: "result-d",
+      type: "result",
+      result: {
+        era: "1947年〜1954年頃",
+        rationale: "®なし＋ダブルステッチ＝最初期モデル",
+      },
+    },
+  ],
+};

--- a/tests/unit/services/diagnostic-flow.test.ts
+++ b/tests/unit/services/diagnostic-flow.test.ts
@@ -1,0 +1,78 @@
+import { getFlowById } from "@/lib/diagnostic-flows/index";
+import type {
+  DiagnosticNode,
+  DiagnosticQuestionNode,
+} from "@/types/diagnostic";
+
+describe("DiagnosticFlow", () => {
+  describe("getFlowById", () => {
+    it("should return flow for valid id 'levis'", () => {
+      const flow = getFlowById("levis");
+      expect(flow).toBeDefined();
+      expect(flow).not.toBeNull();
+    });
+
+    it("should return undefined for unknown id", () => {
+      const flow = getFlowById("nonexistent-brand-xyz");
+      expect(flow).toBeUndefined();
+    });
+
+    it("should return flow with at least one root node", () => {
+      const flow = getFlowById("levis");
+      expect(flow).toBeDefined();
+      const rootNode = flow!.nodes.find((n) => n.id === flow!.rootNodeId);
+      expect(rootNode).toBeDefined();
+    });
+  });
+
+  describe("DiagnosticNode", () => {
+    it("should have question nodes with options array", () => {
+      const flow = getFlowById("levis");
+      expect(flow).toBeDefined();
+      const questionNodes = flow!.nodes.filter(
+        (n): n is DiagnosticQuestionNode => n.type === "question",
+      );
+      expect(questionNodes.length).toBeGreaterThan(0);
+      for (const node of questionNodes) {
+        expect(Array.isArray(node.options)).toBe(true);
+        expect(node.options.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("should have result nodes with era and rationale", () => {
+      const flow = getFlowById("levis");
+      expect(flow).toBeDefined();
+      const resultNodes = flow!.nodes.filter((n) => n.type === "result");
+      expect(resultNodes.length).toBeGreaterThan(0);
+      for (const node of resultNodes) {
+        if (node.type !== "result") continue;
+        expect(typeof node.result.era).toBe("string");
+        expect(node.result.era.length).toBeGreaterThan(0);
+        expect(typeof node.result.rationale).toBe("string");
+        expect(node.result.rationale.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("should allow traversal from root to result", () => {
+      const flow = getFlowById("levis");
+      expect(flow).toBeDefined();
+
+      const nodeMap = new Map<string, DiagnosticNode>(
+        flow!.nodes.map((n) => [n.id, n]),
+      );
+
+      // ルートノードから1つの選択肢を辿り、次のノードに到達できることを確認
+      const root = nodeMap.get(flow!.rootNodeId);
+      expect(root).toBeDefined();
+      expect(root!.type).toBe("question");
+
+      const questionRoot = root as DiagnosticQuestionNode;
+      expect(questionRoot.options.length).toBeGreaterThan(0);
+
+      const firstOption = questionRoot.options[0];
+      expect(firstOption.nextNodeId).toBeDefined();
+      const nextNode = nodeMap.get(firstOption.nextNodeId);
+      expect(nextNode).toBeDefined();
+    });
+  });
+});

--- a/types/diagnostic.ts
+++ b/types/diagnostic.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Option（質問ノードの選択肢）
+// ---------------------------------------------------------------------------
+
+export const DiagnosticOptionSchema = z.object({
+  label: z.string().min(1),
+  nextNodeId: z.string().min(1),
+});
+export type DiagnosticOption = z.infer<typeof DiagnosticOptionSchema>;
+
+// ---------------------------------------------------------------------------
+// 診断結果（結果ノードに埋め込まれるオブジェクト）
+// ---------------------------------------------------------------------------
+
+export const DiagnosticResultSchema = z.object({
+  era: z.string().min(1),
+  rationale: z.string().min(1),
+});
+export type DiagnosticResult = z.infer<typeof DiagnosticResultSchema>;
+
+// ---------------------------------------------------------------------------
+// 質問ノード
+// ---------------------------------------------------------------------------
+
+export const DiagnosticQuestionNodeSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal("question"),
+  question: z.string().min(1),
+  options: z.array(DiagnosticOptionSchema).min(1),
+});
+export type DiagnosticQuestionNode = z.infer<
+  typeof DiagnosticQuestionNodeSchema
+>;
+
+// ---------------------------------------------------------------------------
+// 結果ノード
+// ---------------------------------------------------------------------------
+
+export const DiagnosticResultNodeSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal("result"),
+  result: DiagnosticResultSchema,
+});
+export type DiagnosticResultNode = z.infer<typeof DiagnosticResultNodeSchema>;
+
+// ---------------------------------------------------------------------------
+// ノード（discriminated union）
+// ---------------------------------------------------------------------------
+
+export const DiagnosticNodeSchema = z.discriminatedUnion("type", [
+  DiagnosticQuestionNodeSchema,
+  DiagnosticResultNodeSchema,
+]);
+export type DiagnosticNode = z.infer<typeof DiagnosticNodeSchema>;
+
+// ---------------------------------------------------------------------------
+// 型ガード関数
+// ---------------------------------------------------------------------------
+
+export function isQuestionNode(
+  node: DiagnosticNode,
+): node is DiagnosticQuestionNode {
+  return node.type === "question";
+}
+
+export function isResultNode(
+  node: DiagnosticNode,
+): node is DiagnosticResultNode {
+  return node.type === "result";
+}
+
+// ---------------------------------------------------------------------------
+// フロー全体
+// ---------------------------------------------------------------------------
+
+export const DiagnosticFlowSchema = z.object({
+  id: z.string().min(1),
+  brand: z.string().min(1),
+  targetItem: z.string().min(1),
+  rootNodeId: z.string().min(1),
+  nodes: z.array(DiagnosticNodeSchema).min(1),
+});
+export type DiagnosticFlow = z.infer<typeof DiagnosticFlowSchema>;
+
+// ---------------------------------------------------------------------------
+// 診断セッション状態（フロントエンド用）
+// ---------------------------------------------------------------------------
+
+export const DiagnosticHistoryEntrySchema = z.object({
+  nodeId: z.string().min(1),
+  chosenLabel: z.string().min(1),
+});
+export type DiagnosticHistoryEntry = z.infer<
+  typeof DiagnosticHistoryEntrySchema
+>;
+
+export const DiagnosticSessionSchema = z.object({
+  flowId: z.string().min(1),
+  currentNodeId: z.string().min(1),
+  history: z.array(DiagnosticHistoryEntrySchema),
+});
+export type DiagnosticSession = z.infer<typeof DiagnosticSessionSchema>;


### PR DESCRIPTION
## 変更の概要
ヴィンテージ古着の年代をQ&Aで判別するインタラクティブなフローチャート機能を追加。質問に答えるだけで年代が絞り込める。

## 変更の理由
古着マニアが店頭で行う「タグ・ステッチを見て年代を判定する」ユースケースをアプリで再現するため。

## 変更内容
- `types/diagnostic.ts`: `DiagnosticFlow` / `DiagnosticNode`（question/result の discriminated union）/ `DiagnosticSession` を Zod スキーマ+TypeScript型で定義。型ガード `isQuestionNode` / `isResultNode` も追加
- `lib/diagnostic-flows/levis.ts`: Levi's 501の年代判別フロー（1947年〜1993年の4パターン）
- `lib/diagnostic-flows/index.ts`: `getFlowById(id)` エントリポイント
- `components/features/knowledge/DiagnosticFlowUI.tsx`: Q&Aステップ形式のインタラクティブUIコンポーネント（Client Component）。回答履歴表示・リセット機能付き
- `app/(public)/knowledge/diagnose/page.tsx`: `/knowledge/diagnose` エントリページ
- `tests/unit/services/diagnostic-flow.test.ts`: フロー構造・traversal のユニットテスト（6件）

## テスト方法
```bash
npm test -- --run   # 全65件グリーン
npm run typecheck   # 型エラーなし
npm run lint        # ESLintエラーなし
```

## 影響範囲
- 新規ページ `/knowledge/diagnose` の追加のみ。既存機能への影響なし
- 将来的にブランド追加は `lib/diagnostic-flows/` にファイルを追加するだけで対応可能

## チェックリスト
- [x] コードレビューを依頼した
- [x] テストが完了している（65件グリーン）
- [ ] ドキュメントを更新した（必要に応じて）
- [x] コミットメッセージが適切である

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 診断ツールを追加しました。Levi's 501対象の対話的診断機能により、ユーザーが一連の質問に回答することで、該当する製品情報を取得できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->