### PR TITLE
feat: add 6-axis radar evaluation and align AI prompts with Notion voice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ test-results/
 public/uploads/
 .playwright-mcp/
 
-# local screenshots (root-level only — keep public/**/*.png trackable)
+# local screenshots / spec attachments (root-level only — keep public/**/*.png trackable)
 /*.png
+/*.jpeg
+/*.jpg
 .claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 
 ## リリースノート
 
+### v0.7.0 — 2026-04-26
+
+**6軸評価レーダー基盤 + Notion 出典の AI プロンプト刷新**
+
+- `EvaluationRadar` スキーマを追加（casual / subdued / presence / subtle / formal / colorful の0〜100 スコア）。`Ootd` / `OotdAnalysisResult` / `CreateOotdInput` に optional で組み込み
+- Prisma `Ootd` モデルに `radarScores Json?` を追加（既存レコードは null 許容）
+- `services/ai-analysis.ts` のプロンプトを Notion 出典の few-shot に刷新
+  - `そのコーデを一言で表した言葉.md` の語彙・文学的トーンを `oneLiner` に継承
+  - `コーデを構成する説明文（DESCRIPTION）.md` の分析的・サブカル参照スタイルを `description` に継承
+  - 同時に 6 軸 `radarScores` を生成するよう指示
+- 新規 OOTD 登録フローで `radarScores` を `createOotdAction` にそのまま転送
+- `EvaluationRadarSchema` に対するスキーマテストを追加
+
+---
+
 ### v0.6.0 — 2026-04-25
 
 **#OOTD一覧のラベル整理 + コーデカレンダー3段リデザイン**

--- a/app/(public)/ootd/new/OotdNewPageClient.tsx
+++ b/app/(public)/ootd/new/OotdNewPageClient.tsx
@@ -143,6 +143,9 @@ export function OotdNewPageClient() {
         styles: analysisResult.styles,
         description: analysisResult.description,
         detectedItems: analysisResult.detectedItems,
+        ...(analysisResult.radarScores
+          ? { radarScores: analysisResult.radarScores }
+          : {}),
         tags: data.tags,
       });
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model Ootd {
   styles        Json
   description   String
   detectedItems Json
+  radarScores   Json?
   date          DateTime @default(now())
   tags          String[]
   createdAt     DateTime @default(now())

--- a/services/ai-analysis.ts
+++ b/services/ai-analysis.ts
@@ -2,19 +2,87 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import { OotdAnalysisResultSchema } from "@/types/ootd";
 import type { OotdAnalysisResult } from "@/types/ootd";
 
-const SYSTEM_PROMPT = `Analyze this outfit photo and return a JSON object with exactly this structure:
+/**
+ * Notion 出典 (Master 提供):
+ *   そのコーデを一言で表した言葉.md
+ *   コーデを構成する説明文（DESCRIPTION）.md
+ * AI に語彙・トーン・構造を継承させるための few-shot サンプル。
+ */
+const ONE_LINER_EXAMPLES = [
+  "意志ある柔和の美学",
+  "鋭利なノスタルジー",
+  "静寂に宿る、柔らかな重み",
+  "日常の解体、その詩学",
+  "計算された「崩し」の美学",
+  "胡蝶の午睡",
+  "静謐な倦怠、野心の詩学",
+  "現代のロマンティシズム。柔らかな構築美。",
+  "地下に潜む気品",
+  "都市の矛盾。響き合う旋律。",
+  "日常を打破する、鮮烈な違和感",
+  "大胆な存在感の詩学",
+];
+
+const DESCRIPTION_EXAMPLES = [
+  `### チャイナボタン・トラックジャケット
+主役はチャイナボタンを配したトラックジャケット。伝統的な技法とスポーツシルエットの融合。これは「国潮（グオチャオ）」ムーブメントを象徴する一着。ボトムスには極太のワイドパンツを選択。オーバーサイズなボリュームが、現代のストリートやAcubi（アクビ）的なバランスを生む。テックなヘッドフォンとニュートラルな配色。それらが文化的な参照点を日常の装いへと着地させる。伝統とユースカルチャーの知的な統合。`,
+  `### スタジャンとダックハンターカモ
+スタジャンとダックハンターカモを軸に据える。アメカジの王道を行くアーカイブだ。これをストリートの文脈でアップデートする。グラフィックキャップとワイドシルエットが、既存のテーラリングをボリュームへと変換する。厚底ローファーに白ソックス。アイビーの規範をハラジュク的な感性で解体する。ミリタリーとカレッジをモジュールとして再構成する。現代的なシティボーイのアイデンティティを表現した。`,
+  `### ベルリンの匿名性とブルータリズム
+全身を黒で統一する。重厚な靴で足元を固める。これはベルリンのクラブシーンが重んじる匿名性とタフネスの表現である。シャツとショーツはボクシーなオーバーサイズ。性別の境界を曖昧にする。シアリングのバッグが、その中性的なシルエットをさらに複雑にする。垂れ下がるストラップ。スクエアトゥのダービーシューズ。これらはブルータリズム建築のような、物質的な量感と構造への関心を反映している。`,
+  `### 森ガールの本質と垂直レイヤード
+森ガールの本質は垂直方向のレイヤードにある。チェックのチュニック、セージ色のティアードスカート、ワイドパンツを重ねる。柔らかく、余白のあるシルエットが生まれる。天然素材とアースカラーが基調だ。パフスリーブやハイネックが、田園的なロマンティシズムを添える。遊び心のあるヘアアクセサリーと独特のボリューム感は、原宿のDIY精神を象徴している。身体のラインは重要ではない。質感と個人の物語を優先した表現だ。`,
+];
+
+const SYSTEM_PROMPT = `You are a fashion editor analyzing an outfit photo. Output ONE JSON object (no markdown, no commentary) with exactly this structure:
 {
-  "oneLiner": "A single sentence describing the overall style (in Japanese)",
-  "colorPalette": [{"name": "color name in Japanese", "colorCode": "#RRGGBB", "percentage": 0-100}],
-  "styles": [{"name": "style name in Japanese (e.g. ストリート, アメカジ, モード)", "percentage": 0-100}],
-  "description": "2-3 sentence description of the outfit in Japanese",
-  "detectedItems": [{"name": "item name in Japanese", "imageHint": "brief English description"}]
+  "oneLiner": string,
+  "colorPalette": [{"name": string, "colorCode": "#RRGGBB", "percentage": number}],
+  "styles": [{"name": string, "percentage": number}],
+  "description": string,
+  "detectedItems": [{"name": string, "imageHint": string}],
+  "radarScores": {
+    "casual": number,
+    "subdued": number,
+    "presence": number,
+    "subtle": number,
+    "formal": number,
+    "colorful": number
+  }
 }
-Rules:
-- colorPalette percentages should sum to ~100
-- styles percentages should sum to ~100
-- detectedItems should list all visible clothing/accessories
-- Return ONLY the JSON object, no markdown`;
+
+Language & tone (CRITICAL — write in Japanese, mirror the voice of the examples below):
+
+# oneLiner — 1〜2 文の体言止め・短い詩のような一言
+- 抽象名詞の対比 / 漢語の硬さ / 余白を残す表現を好む
+- サブカルチャー名（Acubi, 原宿, Y2K, グランジ, 森ガール, ベルリン, ボヘミアン 等）を文中に引用してよい
+- 語尾は「〜の美学」「〜の詩学」「〜の造形」「〜の再構築」「〜の残響」など、抽象的に閉じる
+- 例:
+${ONE_LINER_EXAMPLES.map((e) => `  - ${e}`).join("\n")}
+
+# description — 番号タイトル無しの本文のみ。3〜6 文程度
+- 短文を連ねるリズム。1 文 = 1 観察。
+- 主役アイテムの言及 → 文化的参照（Acubi / 原宿 / Y2K / アメカジ / 森ガール / ベルリン / ボヘミアン / バロック / グランジ / クラブカルチャー 等）→ シルエット / 質感 / 配色 / 対比 で展開する
+- 「〜である。」「〜だ。」と断定や、「〜が共存する。」「〜を解体する。」「〜が生まれる。」など、分析的・宣言的なトーン
+- 余計な前置き（「この写真は〜」等）は禁止。観察対象の服そのものに飛び込む
+- 例（参考スタイル）:
+${DESCRIPTION_EXAMPLES.map((e) => e).join("\n\n---\n\n")}
+
+# styles — 既存軸（ストリート / アメカジ / モード / 古着 / フェミニン etc.）を JP 表記。percentages should sum to ~100。
+
+# radarScores — 6 軸を 0〜100 整数で評価
+- casual:    カジュアルさ（ラフ / リラックス / 普段着寄り）
+- subdued:   落ち着いたトーン（彩度の抑制 / 静的 / 渋い）
+- presence:  存在感のある（強い主張 / インパクト / 視線を奪う）
+- subtle:    さりげない（控えめ / 上品な抜け感 / 主張しない）
+- formal:    フォーマル（ドレッシー / きちんと感 / テーラード）
+- colorful:  カラフル（多彩 / 高彩度 / 色数の多さ）
+注意: presence と subtle は対立軸。casual と formal も対立軸。両極端のスコアが同時に高い評価は避ける。
+
+# colorPalette — percentages should sum to ~100。
+# detectedItems — 写真に映る衣服 / アクセサリーを全件。
+
+Return ONLY the JSON object.`;
 
 export async function analyzeOutfit(
   imageBase64: string,

--- a/services/ootd-service.ts
+++ b/services/ootd-service.ts
@@ -3,6 +3,7 @@ import {
   ColorPaletteItemSchema,
   StyleItemSchema,
   DetectedItemSchema,
+  EvaluationRadarSchema,
   CreateOotdInput,
 } from "@/types/ootd";
 import type { Ootd, SortOrder } from "@/types/ootd";
@@ -24,6 +25,12 @@ function parseDetectedItems(raw: Prisma.JsonValue) {
   return parsed.success ? parsed.data : [];
 }
 
+function parseRadarScores(raw: Prisma.JsonValue | null) {
+  if (raw === null) return undefined;
+  const parsed = EvaluationRadarSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
 function parseOotdRecord(record: {
   id: string;
   imageUrl: string;
@@ -33,11 +40,13 @@ function parseOotdRecord(record: {
   styles: Prisma.JsonValue;
   description: string;
   detectedItems: Prisma.JsonValue;
+  radarScores: Prisma.JsonValue | null;
   date: Date;
   tags: string[];
   createdAt: Date;
   updatedAt: Date;
 }): Ootd {
+  const radarScores = parseRadarScores(record.radarScores);
   return {
     id: record.id,
     imageUrl: record.imageUrl,
@@ -47,6 +56,7 @@ function parseOotdRecord(record: {
     styles: parseStyles(record.styles),
     description: record.description,
     detectedItems: parseDetectedItems(record.detectedItems),
+    ...(radarScores ? { radarScores } : {}),
     date: record.date,
     tags: record.tags,
     createdAt: record.createdAt,
@@ -81,6 +91,7 @@ export async function createOotd(
       styles: input.styles,
       description: input.description,
       detectedItems: input.detectedItems,
+      radarScores: input.radarScores ?? Prisma.JsonNull,
       tags: input.tags,
       ...(input.date !== undefined ? { date: input.date } : {}),
     },

--- a/tests/unit/services/ootd-schema.test.ts
+++ b/tests/unit/services/ootd-schema.test.ts
@@ -4,6 +4,7 @@ import {
   StyleItemSchema,
   DetectedItemSchema,
   CreateOotdInputSchema,
+  EvaluationRadarSchema,
 } from "@/types/ootd";
 
 // ---------------------------------------------------------------------------
@@ -249,6 +250,76 @@ describe("OotdSchema", () => {
       ...validOotd,
       createdAt: "2026-03-15",
     });
+    expect(result.success).toBe(false);
+  });
+
+  it("radarScores が optional のため、欠落していてもパースできる", () => {
+    const result = OotdSchema.safeParse(validOotd);
+    expect(result.success).toBe(true);
+  });
+
+  it("radarScores が 6 軸揃っていればパースできる", () => {
+    const result = OotdSchema.safeParse({
+      ...validOotd,
+      radarScores: {
+        casual: 80,
+        subdued: 50,
+        presence: 70,
+        subtle: 30,
+        formal: 20,
+        colorful: 60,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("radarScores の軸が欠けているとバリデーションエラーになる", () => {
+    const result = OotdSchema.safeParse({
+      ...validOotd,
+      radarScores: { casual: 80, subdued: 50 },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EvaluationRadarSchema
+// ---------------------------------------------------------------------------
+describe("EvaluationRadarSchema", () => {
+  const validRadar = {
+    casual: 0,
+    subdued: 50,
+    presence: 100,
+    subtle: 25,
+    formal: 75,
+    colorful: 60,
+  };
+
+  it("6 軸が 0〜100 の範囲でパースできる", () => {
+    const result = EvaluationRadarSchema.safeParse(validRadar);
+    expect(result.success).toBe(true);
+  });
+
+  it("いずれかの軸が 100 を超えるとバリデーションエラーになる", () => {
+    const result = EvaluationRadarSchema.safeParse({
+      ...validRadar,
+      formal: 101,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("いずれかの軸が負の値でバリデーションエラーになる", () => {
+    const result = EvaluationRadarSchema.safeParse({
+      ...validRadar,
+      colorful: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("軸が欠落するとバリデーションエラーになる", () => {
+    const { casual: _omit, ...partial } = validRadar;
+    void _omit;
+    const result = EvaluationRadarSchema.safeParse(partial);
     expect(result.success).toBe(false);
   });
 });

--- a/tests/unit/services/ootd-service.test.ts
+++ b/tests/unit/services/ootd-service.test.ts
@@ -37,6 +37,7 @@ const makeOotdRecord = (id: string, createdAt: Date) => ({
   styles: [{ name: "ストリート", percentage: 100 }],
   description: "ヴィンテージデニムを主役にしたコーデ",
   detectedItems: [{ name: "デニムジャケット" }],
+  radarScores: null,
   date: new Date("2026-03-15"),
   tags: ["古着"],
   createdAt,
@@ -151,6 +152,7 @@ describe("createOotd", () => {
       ...input,
       id: "uuid-new",
       stickerUrl: null,
+      radarScores: null,
       createdAt: new Date("2026-04-01T10:00:00Z"),
       updatedAt: new Date("2026-04-01T10:00:00Z"),
     };
@@ -181,6 +183,7 @@ describe("createOotd", () => {
       ...input,
       id: "uuid-created",
       stickerUrl: null,
+      radarScores: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/types/ootd.ts
+++ b/types/ootd.ts
@@ -24,6 +24,35 @@ export const DetectedItemSchema = z.object({
 });
 export type DetectedItem = z.infer<typeof DetectedItemSchema>;
 
+export const RADAR_AXES = [
+  "casual",
+  "subdued",
+  "presence",
+  "subtle",
+  "formal",
+  "colorful",
+] as const;
+export type RadarAxis = (typeof RADAR_AXES)[number];
+
+export const RADAR_AXIS_LABELS: Record<RadarAxis, string> = {
+  casual: "カジュアル",
+  subdued: "落ち着いたトーン",
+  presence: "存在感のある",
+  subtle: "さりげない",
+  formal: "フォーマル",
+  colorful: "カラフル",
+};
+
+export const EvaluationRadarSchema = z.object({
+  casual: z.number().min(0).max(100),
+  subdued: z.number().min(0).max(100),
+  presence: z.number().min(0).max(100),
+  subtle: z.number().min(0).max(100),
+  formal: z.number().min(0).max(100),
+  colorful: z.number().min(0).max(100),
+});
+export type EvaluationRadar = z.infer<typeof EvaluationRadarSchema>;
+
 export const OotdSchema = z.object({
   id: z.string().uuid(),
   imageUrl: z.string().min(1),
@@ -33,6 +62,7 @@ export const OotdSchema = z.object({
   styles: z.array(StyleItemSchema),
   description: z.string().min(1),
   detectedItems: z.array(DetectedItemSchema),
+  radarScores: EvaluationRadarSchema.optional(),
   date: z.date(),
   tags: z.array(z.string()).max(3),
   createdAt: z.date(),
@@ -48,6 +78,7 @@ export const CreateOotdInputSchema = z.object({
   styles: z.array(StyleItemSchema),
   description: z.string().min(1),
   detectedItems: z.array(DetectedItemSchema),
+  radarScores: EvaluationRadarSchema.optional(),
   tags: z.array(z.string()).max(3),
 });
 export type CreateOotdInput = z.infer<typeof CreateOotdInputSchema>;
@@ -78,6 +109,7 @@ export const OotdAnalysisResultSchema = z.object({
   styles: z.array(StyleItemSchema),
   description: z.string().min(1),
   detectedItems: z.array(DetectedItemSchema),
+  radarScores: EvaluationRadarSchema.optional(),
 });
 export type OotdAnalysisResult = z.infer<typeof OotdAnalysisResultSchema>;
 


### PR DESCRIPTION
## Summary
PR1/2 — データ層 + AI プロンプト整備（UI 反映は次PRで対応）

- 6 軸評価スキーマ \`EvaluationRadar\`（casual/subdued/presence/subtle/formal/colorful）を導入し、Ootd / OotdAnalysisResult / CreateOotdInput に optional で追加
- Prisma \`Ootd\` モデルに \`radarScores Json?\` を追加（既存レコードは null 許容）
- AI 分析 (\`services/ai-analysis.ts\`) のプロンプトを Notion 出典の few-shot に刷新
  - \`そのコーデを一言で表した言葉.md\` の語彙・文学的トーンを oneLiner に継承
  - \`コーデを構成する説明文（DESCRIPTION）.md\` の分析的・サブカル参照を description に継承
  - 6 軸 radarScores も同時生成
- 新規 OOTD 登録フローで radarScores をそのまま \`createOotdAction\` に渡す
- 仕様参照ファイル（jpeg / jpg）は \`.gitignore\` でルート直下のみ無視

## Out of scope
- 6 軸 RadarChart UI / SP 詳細ポップアップは PR2 で対応

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm run build\`
- [x] \`npm test -- --run\`（68 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * OOTD に 6軸のレーダースコア評価を追加し、登録時にスコアを保存・利用できるようにしました。
  * AI 分析の指示を改善し、より詳細なスタイル評価（one-liner/description とレーダースコア）を生成します。

* **テスト**
  * レーダースコアの妥当性検証を含む単体テストを追加しました。

* **その他**
  * ルートの画像添付（png/jpg/jpeg 等）とスクリーンショットを無視する設定を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->