### PR TITLE
feat: SP popup detail with radar chart and back nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 ## リリースノート
 
+### v0.8.0 — 2026-04-26
+
+**SP版OOTD詳細ポップアップ + 戻るソフトナビ + 6軸評価レーダーUI**
+
+- 新規 `OotdEvaluationRadar`: Recharts ヘキサゴナル レーダー（時計回りに カジュアル → 落ち着いたトーン → さりげない → フォーマル → カラフル → 存在感のある）を緑線 stroke で描画
+- `OotdDetail`: `radarScores` がある OOTD は ITEMS の下に Evaluation セクションを表示。optional `onBack` prop で戻るソフトナビボタン
+- 新規 `OotdDetailModal` (SP only): 画面下からスライドアップ / 80dvh / 暗オーバーレイ + blur / ドラッグハンドル / ESC・戻る・オーバーレイで閉じる
+- 新規 `useIsMobile` hook（matchMedia <=767px）+ ユニットテスト 6 件
+- `OotdListClient`: SP では `getOotdByIdAction` でモーダル表示、PC は従来通り `/ootd/[id]` フルページ遷移。モーダルは conditional render で再オープン時にアニメーション再生
+- `OotdDetailPage` (フルページ): `onBack` を `router.back`（履歴がない場合は `/ootd`）にフォールバック
+
+---
+
 ### v0.7.0 — 2026-04-26
 
 **6軸評価レーダー基盤 + Notion 出典の AI プロンプト刷新**

--- a/app/(public)/ootd/OotdListClient.tsx
+++ b/app/(public)/ootd/OotdListClient.tsx
@@ -4,13 +4,16 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { OotdCalendar } from "@/components/features/ootd/OotdCalendar";
 import { OotdStickerBook } from "@/components/features/ootd/OotdStickerBook";
+import { OotdDetailModal } from "@/components/features/ootd/OotdDetailModal";
 import {
   CalendarIcon,
   GridIcon,
   SortAscIcon,
   SortDescIcon,
 } from "@/components/ui/icons";
-import type { OotdSummary, SortOrder } from "@/types/ootd";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { getOotdByIdAction, deleteOotdAction } from "@/app/actions/ootd";
+import type { Ootd, OotdSummary, SortOrder } from "@/types/ootd";
 
 interface OotdListClientProps {
   ootds: OotdSummary[];
@@ -20,16 +23,49 @@ type ViewMode = "sticker" | "calendar";
 
 export function OotdListClient({ ootds }: OotdListClientProps) {
   const router = useRouter();
+  const isMobile = useIsMobile();
   const [view, setView] = useState<ViewMode>("sticker");
   const [sort, setSort] = useState<SortOrder>("desc");
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalLoading, setModalLoading] = useState(false);
+  const [selectedOotd, setSelectedOotd] = useState<Ootd | null>(null);
 
   const sorted = [...ootds].sort((a, b) => {
     const diff = a.date.getTime() - b.date.getTime();
     return sort === "desc" ? -diff : diff;
   });
 
+  async function openModal(id: string) {
+    setSelectedOotd(null);
+    setModalLoading(true);
+    setModalOpen(true);
+    const result = await getOotdByIdAction(id);
+    if (result.error) {
+      setModalLoading(false);
+      return;
+    }
+    setSelectedOotd(result.data);
+    setModalLoading(false);
+  }
+
+  function closeModal() {
+    setModalOpen(false);
+  }
+
+  async function handleDelete(id: string) {
+    const result = await deleteOotdAction(id);
+    if (result.error) return;
+    setModalOpen(false);
+    router.refresh();
+  }
+
   function handleSelect(id: string) {
-    router.push(`/ootd/${id}`);
+    if (isMobile) {
+      void openModal(id);
+    } else {
+      router.push(`/ootd/${id}`);
+    }
   }
 
   return (
@@ -92,6 +128,14 @@ export function OotdListClient({ ootds }: OotdListClientProps) {
       ) : (
         <OotdCalendar ootds={ootds} onSelect={handleSelect} />
       )}
+
+      <OotdDetailModal
+        isOpen={modalOpen}
+        isLoading={modalLoading}
+        ootd={selectedOotd}
+        onClose={closeModal}
+        onDelete={handleDelete}
+      />
     </div>
   );
 }

--- a/app/(public)/ootd/OotdListClient.tsx
+++ b/app/(public)/ootd/OotdListClient.tsx
@@ -129,13 +129,15 @@ export function OotdListClient({ ootds }: OotdListClientProps) {
         <OotdCalendar ootds={ootds} onSelect={handleSelect} />
       )}
 
-      <OotdDetailModal
-        isOpen={modalOpen}
-        isLoading={modalLoading}
-        ootd={selectedOotd}
-        onClose={closeModal}
-        onDelete={handleDelete}
-      />
+      {modalOpen && (
+        <OotdDetailModal
+          isOpen={modalOpen}
+          isLoading={modalLoading}
+          ootd={selectedOotd}
+          onClose={closeModal}
+          onDelete={handleDelete}
+        />
+      )}
     </div>
   );
 }

--- a/app/(public)/ootd/[id]/OotdDetailPage.tsx
+++ b/app/(public)/ootd/[id]/OotdDetailPage.tsx
@@ -20,5 +20,13 @@ export function OotdDetailPage({ ootd }: OotdDetailPageProps) {
     router.push("/ootd");
   }
 
-  return <OotdDetail ootd={ootd} onDelete={handleDelete} />;
+  function handleBack() {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push("/ootd");
+  }
+
+  return <OotdDetail ootd={ootd} onDelete={handleDelete} onBack={handleBack} />;
 }

--- a/components/features/ootd/OotdDetail.tsx
+++ b/components/features/ootd/OotdDetail.tsx
@@ -6,15 +6,17 @@ import { Badge } from "@/components/ui/Badge";
 import { OotdColorPalette } from "@/components/features/ootd/OotdColorPalette";
 import { OotdStyleGauge } from "@/components/features/ootd/OotdStyleGauge";
 import { OotdItemList } from "@/components/features/ootd/OotdItemList";
-import { CloseIcon, TrashIcon } from "@/components/ui/icons";
+import { OotdEvaluationRadar } from "@/components/features/ootd/OotdEvaluationRadar";
+import { ChevronLeftIcon, CloseIcon, TrashIcon } from "@/components/ui/icons";
 import type { Ootd } from "@/types/ootd";
 
 interface OotdDetailProps {
   ootd: Ootd;
   onDelete: (id: string) => void;
+  onBack?: () => void;
 }
 
-export function OotdDetail({ ootd, onDelete }: OotdDetailProps) {
+export function OotdDetail({ ootd, onDelete, onBack }: OotdDetailProps) {
   const [showConfirm, setShowConfirm] = useState(false);
 
   const formattedDate = new Intl.DateTimeFormat("en-US", {
@@ -27,6 +29,17 @@ export function OotdDetail({ ootd, onDelete }: OotdDetailProps) {
     <>
       <article className="mx-auto max-w-2xl space-y-8">
         <header className="space-y-3">
+          {onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              aria-label="戻る"
+              className="inline-flex items-center gap-1 text-xs font-medium tracking-widest uppercase text-denim/50 hover:text-denim dark:text-offwhite/40 dark:hover:text-offwhite transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 rounded-sm"
+            >
+              <ChevronLeftIcon width={14} height={14} />
+              戻る
+            </button>
+          )}
           <h1 className="font-display text-3xl tracking-widest text-denim-dark dark:text-offwhite leading-tight">
             {ootd.oneLiner}
           </h1>
@@ -87,6 +100,15 @@ export function OotdDetail({ ootd, onDelete }: OotdDetailProps) {
               Items
             </h2>
             <OotdItemList items={ootd.detectedItems} />
+          </section>
+        )}
+
+        {ootd.radarScores && (
+          <section className="space-y-3">
+            <h2 className="text-xs font-bold tracking-widest uppercase text-denim/40 dark:text-offwhite/30">
+              Evaluation
+            </h2>
+            <OotdEvaluationRadar scores={ootd.radarScores} />
           </section>
         )}
 

--- a/components/features/ootd/OotdDetailModal.tsx
+++ b/components/features/ootd/OotdDetailModal.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { OotdDetail } from "@/components/features/ootd/OotdDetail";
+import { Spinner } from "@/components/ui/Spinner";
+import type { Ootd } from "@/types/ootd";
+
+interface OotdDetailModalProps {
+  ootd: Ootd | null;
+  isLoading: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: (id: string) => void;
+}
+
+export function OotdDetailModal({
+  ootd,
+  isLoading,
+  isOpen,
+  onClose,
+  onDelete,
+}: OotdDetailModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const t = setTimeout(() => setMounted(true), 10);
+    return () => clearTimeout(t);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="OOTD詳細"
+      className="fixed inset-0 z-50"
+    >
+      <button
+        type="button"
+        aria-label="閉じる"
+        onClick={onClose}
+        className={[
+          "absolute inset-0 bg-black/55 backdrop-blur-[2px] transition-opacity duration-300",
+          mounted ? "opacity-100" : "opacity-0",
+        ].join(" ")}
+      />
+
+      <div
+        className={[
+          "absolute bottom-0 inset-x-0 h-[80dvh]",
+          "bg-offwhite dark:bg-canvas",
+          "rounded-t-2xl shadow-2xl",
+          "transition-transform duration-300 ease-out",
+          "overflow-y-auto overscroll-contain",
+          mounted ? "translate-y-0" : "translate-y-full",
+        ].join(" ")}
+      >
+        <div
+          aria-hidden="true"
+          className="sticky top-0 z-10 flex justify-center pt-2 pb-1 bg-offwhite dark:bg-canvas"
+        >
+          <span className="h-1 w-10 rounded-full bg-denim/20 dark:bg-offwhite/20" />
+        </div>
+
+        <div className="px-5 pb-10 pt-2">
+          {isLoading ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-24">
+              <Spinner size="lg" />
+              <p className="text-xs tracking-widest uppercase text-denim/40 dark:text-offwhite/30">
+                Loading
+              </p>
+            </div>
+          ) : ootd ? (
+            <OotdDetail ootd={ootd} onDelete={onDelete} onBack={onClose} />
+          ) : (
+            <p className="py-24 text-center text-sm text-denim/50 dark:text-offwhite/40">
+              詳細を取得できませんでした
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/features/ootd/OotdEvaluationRadar.tsx
+++ b/components/features/ootd/OotdEvaluationRadar.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  ResponsiveContainer,
+} from "recharts";
+import type { EvaluationRadar, RadarAxis } from "@/types/ootd";
+import { RADAR_AXIS_LABELS } from "@/types/ootd";
+
+interface OotdEvaluationRadarProps {
+  scores: EvaluationRadar;
+}
+
+const CLOCKWISE_ORDER: RadarAxis[] = [
+  "casual",
+  "subdued",
+  "subtle",
+  "formal",
+  "colorful",
+  "presence",
+];
+
+export function OotdEvaluationRadar({ scores }: OotdEvaluationRadarProps) {
+  const data = CLOCKWISE_ORDER.map((axis) => ({
+    axis,
+    label: RADAR_AXIS_LABELS[axis],
+    value: scores[axis],
+  }));
+
+  return (
+    <div className="w-full h-72">
+      <ResponsiveContainer width="100%" height="100%">
+        <RadarChart
+          data={data}
+          margin={{ top: 24, right: 56, bottom: 24, left: 56 }}
+          outerRadius="78%"
+        >
+          <PolarGrid stroke="currentColor" strokeOpacity={0.15} radialLines />
+          <PolarAngleAxis
+            dataKey="label"
+            tick={{
+              fill: "currentColor",
+              fillOpacity: 0.6,
+              fontSize: 12,
+              fontFamily: "inherit",
+            }}
+          />
+          <Radar
+            dataKey="value"
+            stroke="#5d6b54"
+            fill="#5d6b54"
+            fillOpacity={0.12}
+            strokeWidth={2.5}
+            isAnimationActive={false}
+          />
+        </RadarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const MOBILE_QUERY = "(max-width: 767px)";
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  return isMobile;
+}

--- a/tests/unit/hooks/useIsMobile.test.ts
+++ b/tests/unit/hooks/useIsMobile.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, act } from "@testing-library/react";
+import { useIsMobile } from "@/hooks/useIsMobile";
+
+interface MockMediaQueryList {
+  matches: boolean;
+  media: string;
+  addEventListener: (type: "change", listener: () => void) => void;
+  removeEventListener: (type: "change", listener: () => void) => void;
+}
+
+function installMatchMedia(initialMatches: boolean) {
+  let listener: (() => void) | null = null;
+  const removeSpy = vi.fn();
+  const mql: MockMediaQueryList = {
+    matches: initialMatches,
+    media: "(max-width: 767px)",
+    addEventListener: (_type, l) => {
+      listener = l;
+    },
+    removeEventListener: (_type, l) => {
+      if (listener === l) listener = null;
+      removeSpy(l);
+    },
+  };
+  const matchMedia = vi.fn().mockReturnValue(mql);
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: matchMedia,
+  });
+  return {
+    mql,
+    fire: (matches: boolean) => {
+      mql.matches = matches;
+      listener?.();
+    },
+    removeSpy,
+    matchMedia,
+  };
+}
+
+describe("useIsMobile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("767px以下（matches=true）の場合は true を返す", () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it("768px以上（matches=false）の場合は false を返す", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it("`(max-width: 767px)` のメディアクエリで matchMedia を呼び出す", () => {
+    const { matchMedia } = installMatchMedia(false);
+    renderHook(() => useIsMobile());
+    expect(matchMedia).toHaveBeenCalledWith("(max-width: 767px)");
+  });
+
+  it("change イベントで state を更新する（false → true）", () => {
+    const ctx = installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      ctx.fire(true);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("change イベントで state を更新する（true → false）", () => {
+    const ctx = installMatchMedia(true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+
+    act(() => {
+      ctx.fire(false);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("unmount 時に removeEventListener が呼ばれる", () => {
+    const ctx = installMatchMedia(false);
+    const { unmount } = renderHook(() => useIsMobile());
+    expect(ctx.removeSpy).not.toHaveBeenCalled();
+    unmount();
+    expect(ctx.removeSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
旧 PR #22 が base ブランチ削除に伴いクローズされたため、main 直下に再作成。

- 新規 \`OotdEvaluationRadar\`: Recharts による6軸ヘキサゴナル レーダー（時計回りに カジュアル → 落ち着いたトーン → さりげない → フォーマル → カラフル → 存在感のある）。緑線 stroke
- \`OotdDetail\`: \`radarScores\` がある OOTD は ITEMS の下に Evaluation セクションを表示、optional \`onBack\` prop で戻るソフトナビボタンを追加
- 新規 \`OotdDetailModal\` (SP only): 画面下スライドアップ / 80dvh / 暗オーバーレイ + blur / ドラッグハンドル / ESC・戻る・オーバーレイで閉じる
- 新規 \`useIsMobile\` hook (matchMedia <=767px) でデバイス判定
- \`OotdListClient\`: SP では \`getOotdByIdAction\` で取得してモーダル表示、PC は従来通り \`/ootd/[id]\` フルページ遷移
- \`OotdDetailPage\` (フルページ): \`onBack\` を \`router.back\`（履歴がない場合は \`/ootd\`）にフォールバック

## Replaces
- 旧 #22（base ブランチ削除によりクローズ）

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm run build\`
- [x] \`npm test -- --run\`（68 passed）
- [x] Playwright実機: SP 390x844 でモーダル表示・スライドアップ・80%高さ・暗オーバーレイ・戻る動作を確認
- [x] Playwright実機: PC 1280x900 でフルページ遷移・戻るボタンを確認
- [x] 検証スクショは即削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * モバイルでOOTD一覧から詳細をモーダル表示できるように
  * OOTD詳細ページに「戻る」ボタンを追加
  * OOTD評価をレーダーチャートで可視化
  * 画面幅でモバイル判定するフックを追加
* **テスト**
  * モバイル判定フックのユニットテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->