### PR TITLE
OOTD: SP camera capture, supabase storage, bottom nav icons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ DIRECT_URL=postgresql://postgres:postgres@localhost:5433/dig_dev
 # Supabase (本番環境)
 SUPABASE_URL=
 SUPABASE_KEY=
+# Supabase Storage (本番環境の画像ストレージ)
+SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_STORAGE_BUCKET=ootd-images
+
+# 画像ストレージ駆動方式: "local"（既定: public/uploads/） | "supabase"
+STORAGE_DRIVER=local
 
 # Notion MCP（/knowledge-update コマンドで使用）
 NOTION_KNOWLEDGE_DATA_SOURCE_ID=

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,7 @@ DIRECT_URL=postgresql://postgres:postgres@localhost:5433/dig_dev
 
 # Supabase (本番環境)
 SUPABASE_URL=
-SUPABASE_KEY=
-# Supabase Storage (本番環境の画像ストレージ)
+# Supabase Storage (本番環境の画像ストレージ。サーバ側のみ使用)
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_STORAGE_BUCKET=ootd-images
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,9 @@ out/
 build/
 dist/
 
-# env
+# env (.env.example はテンプレートとしてコミットする)
 .env
 .env.local
-.env.example
 .env.development
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@
 
 ## リリースノート
 
+### v0.9.0 — 2026-04-29
+
+**SP カメラ起動 + 本番画像ストレージ（Supabase Storage）+ HEIC 対応 + ボトムナビ刷新**
+
+- SP では `/ootd/new` の画像入力に `capture="environment"` を付与しカメラ直起動。PC は通常のファイル選択ダイアログ
+- 本番画像ストレージとして Supabase Storage を導入（`STORAGE_DRIVER=local|supabase` で切替）
+  - 新規 `lib/storage.ts` に driver 抽象を実装。ローカル開発は `public/uploads/` を維持
+  - 拡張子サニタイズ（`^\.[a-z0-9]{1,10}$` のみ許可、不正なら `.jpg`）
+  - `STORAGE_DRIVER` の不正値は例外で早期検知
+- 署名 URL 経由のクライアント直接アップロードを追加（`/api/upload-url`）
+  - JPEG/PNG/WebP/GIF はブラウザから Supabase に直接 PUT
+  - HEIC/HEIF は `/api/upload` 経由でサーバ側 JPEG 変換（`heic-convert`、Vercel 互換）
+- アップロードのセキュリティ強化
+  - MIME を allowlist 化（`image/svg+xml` 等のアクティブコンテンツを排除）
+  - ファイルサイズ 10MB 上限、超過で 413 早期リターン
+- ボトムナビのアイコンを内容に合致したものへ変更
+  - 着こなし検索: `ClockIcon` → `SearchIcon`（「検索」ラベル）
+  - OOTD一覧: `UserIcon` → `CalendarIcon`（「一覧」ラベル）
+- `.env.example` 整理（未使用 `SUPABASE_KEY` を削除、`SUPABASE_SERVICE_ROLE_KEY` / `SUPABASE_STORAGE_BUCKET` / `STORAGE_DRIVER` を追加）
+- 動作確認スクリプト `scripts/smoke-supabase-storage.mjs`（PUT/GET/DELETE と Content-Type 検証）
+
+---
+
 ### v0.8.0 — 2026-04-26
 
 **SP版OOTD詳細ポップアップ + 戻るソフトナビ + 6軸評価レーダーUI**

--- a/app/(public)/ootd/new/OotdNewPageClient.tsx
+++ b/app/(public)/ootd/new/OotdNewPageClient.tsx
@@ -8,6 +8,7 @@ import { OotdRegisterForm } from "@/components/features/ootd/OotdRegisterForm";
 import { createOotdAction } from "@/app/actions/ootd";
 import { ImageIcon, SparkleIcon } from "@/components/ui/icons";
 import { Spinner } from "@/components/ui/Spinner";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import type { OotdAnalysisResult } from "@/types/ootd";
 
 type Step = "upload" | "analysis" | "register";
@@ -15,6 +16,7 @@ type Step = "upload" | "analysis" | "register";
 export function OotdNewPageClient() {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const isMobile = useIsMobile();
 
   const [step, setStep] = useState<Step>("upload");
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -212,6 +214,7 @@ export function OotdNewPageClient() {
             ref={fileInputRef}
             type="file"
             accept="image/*"
+            {...(isMobile ? { capture: "environment" as const } : {})}
             className="sr-only"
             onChange={handleFileChange}
             aria-label="コーデ画像"

--- a/app/(public)/ootd/new/OotdNewPageClient.tsx
+++ b/app/(public)/ootd/new/OotdNewPageClient.tsx
@@ -30,6 +30,62 @@ export function OotdNewPageClient() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  // HEIC/HEIF は他ブラウザで表示できないため、サーバーサイドで JPEG 変換する経路に回す。
+  const HEIC_TYPES = new Set(["image/heic", "image/heif"]);
+
+  async function uploadDirect(file: File): Promise<string> {
+    // 1. /api/upload-url で署名URL取得
+    const issueRes = await fetch("/api/upload-url", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mimeType: file.type,
+        originalName: file.name,
+      }),
+    });
+    const issueJson = (await issueRes.json()) as {
+      signedUrl?: string;
+      publicUrl?: string;
+      error?: { message: string };
+    };
+    if (!issueRes.ok || !issueJson.signedUrl || !issueJson.publicUrl) {
+      throw new Error(
+        issueJson.error?.message ?? "アップロードURLの発行に失敗しました",
+      );
+    }
+
+    // 2. 署名URLへ直接 PUT
+    const putRes = await fetch(issueJson.signedUrl, {
+      method: "PUT",
+      headers: { "Content-Type": file.type },
+      body: file,
+    });
+    if (!putRes.ok) {
+      throw new Error("画像のアップロードに失敗しました");
+    }
+
+    return issueJson.publicUrl;
+  }
+
+  async function uploadViaServer(file: File): Promise<string> {
+    const formData = new FormData();
+    formData.append("image", file);
+
+    const res = await fetch("/api/upload", {
+      method: "POST",
+      body: formData,
+    });
+    const json = (await res.json()) as {
+      url?: string;
+      error?: { message: string };
+    };
+
+    if (!res.ok || !json.url) {
+      throw new Error(json.error?.message ?? "アップロードに失敗しました");
+    }
+    return json.url;
+  }
+
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -39,23 +95,10 @@ export function OotdNewPageClient() {
     setIsUploading(true);
 
     try {
-      const formData = new FormData();
-      formData.append("image", file);
-
-      const res = await fetch("/api/upload", {
-        method: "POST",
-        body: formData,
-      });
-      const json = (await res.json()) as {
-        url?: string;
-        error?: { message: string };
-      };
-
-      if (!res.ok || !json.url) {
-        throw new Error(json.error?.message ?? "アップロードに失敗しました");
-      }
-
-      setUploadedUrl(json.url);
+      const url = HEIC_TYPES.has(file.type)
+        ? await uploadViaServer(file)
+        : await uploadDirect(file);
+      setUploadedUrl(url);
     } catch (err) {
       setErrorMessage(
         err instanceof Error ? err.message : "アップロードに失敗しました",

--- a/app/api/upload-url/route.ts
+++ b/app/api/upload-url/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { createSignedUploadUrl } from "@/lib/storage";
+import { SignedUploadUrlRequestSchema } from "@/types/upload";
+
+/**
+ * POST /api/upload-url
+ *
+ * クライアント直接アップロード（署名URL方式）の入口。
+ * 入力 mimeType は HEIC/HEIF 以外の主要画像形式のみ受理する。
+ * HEIC/HEIF は別経路（POST /api/upload）でサーバーサイド変換してから保存する。
+ */
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        data: null,
+        error: { message: "Invalid JSON body", code: "VALIDATION_ERROR" },
+      },
+      { status: 400 },
+    );
+  }
+
+  const parsed = SignedUploadUrlRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        data: null,
+        error: {
+          message: "Invalid input",
+          code: "VALIDATION_ERROR",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const { signedUrl, path, publicUrl } = await createSignedUploadUrl(
+      parsed.data.mimeType,
+      parsed.data.originalName,
+    );
+    return NextResponse.json(
+      { signedUrl, path, publicUrl },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("[upload-url]", error);
+    return NextResponse.json(
+      {
+        data: null,
+        error: { message: "Internal server error", code: "INTERNAL_ERROR" },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { writeFile, mkdir } from "fs/promises";
-import { join, extname } from "path";
-import { randomUUID } from "crypto";
+import { uploadImage } from "@/lib/storage";
 
 export async function POST(request: Request) {
   const formData = await request.formData();
@@ -9,34 +7,39 @@ export async function POST(request: Request) {
 
   if (!file || !(file instanceof File)) {
     return NextResponse.json(
-      { data: null, error: { message: "No image file provided", code: "MISSING_FILE" } },
+      {
+        data: null,
+        error: { message: "No image file provided", code: "MISSING_FILE" },
+      },
       { status: 400 },
     );
   }
 
   if (!file.type.startsWith("image/")) {
     return NextResponse.json(
-      { data: null, error: { message: "Only image files are allowed", code: "INVALID_FILE_TYPE" } },
+      {
+        data: null,
+        error: {
+          message: "Only image files are allowed",
+          code: "INVALID_FILE_TYPE",
+        },
+      },
       { status: 400 },
     );
   }
 
   try {
-    const ext = extname(file.name) || ".jpg";
-    const filename = `${randomUUID()}${ext}`;
-    const uploadsDir = join(process.cwd(), "public", "uploads");
-
-    await mkdir(uploadsDir, { recursive: true });
-
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
-    await writeFile(join(uploadsDir, filename), buffer);
-
-    return NextResponse.json({ url: `/uploads/${filename}` }, { status: 200 });
+    const { url } = await uploadImage(buffer, file.type, file.name);
+    return NextResponse.json({ url }, { status: 200 });
   } catch (error) {
     console.error("[upload]", error);
     return NextResponse.json(
-      { data: null, error: { message: "Internal server error", code: "INTERNAL_ERROR" } },
+      {
+        data: null,
+        error: { message: "Internal server error", code: "INTERNAL_ERROR" },
+      },
       { status: 500 },
     );
   }

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from "next/server";
 import { uploadImage, convertHeicToJpeg } from "@/lib/storage";
-import { HEIC_MIME_TYPES } from "@/types/upload";
+import { DIRECT_UPLOAD_MIME_TYPES, HEIC_MIME_TYPES } from "@/types/upload";
 
 const MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 const HEIC_MIME_SET = new Set<string>(HEIC_MIME_TYPES);
+// image/svg+xml 等のアクティブコンテンツを排除するため、サポート MIME を allowlist で固定する。
+const ALLOWED_IMAGE_MIME_TYPES = new Set<string>([
+  ...DIRECT_UPLOAD_MIME_TYPES,
+  ...HEIC_MIME_TYPES,
+]);
 
 function isHeic(mimeType: string): boolean {
   return HEIC_MIME_SET.has(mimeType.toLowerCase());
@@ -28,7 +33,8 @@ export async function POST(request: Request) {
     );
   }
 
-  if (!file.type.startsWith("image/")) {
+  const mimeType = file.type.toLowerCase();
+  if (!ALLOWED_IMAGE_MIME_TYPES.has(mimeType)) {
     return NextResponse.json(
       {
         data: null,
@@ -54,17 +60,17 @@ export async function POST(request: Request) {
   try {
     const bytes = await file.arrayBuffer();
     let buffer: Buffer = Buffer.from(bytes);
-    let mimeType: string = file.type;
+    let storeMime: string = mimeType;
     let name: string = file.name;
 
-    if (isHeic(file.type)) {
+    if (isHeic(mimeType)) {
       // ブラウザ表示互換のため HEIC/HEIF はサーバーサイドで JPEG 化してから保存。
       buffer = await convertHeicToJpeg(buffer);
-      mimeType = "image/jpeg";
+      storeMime = "image/jpeg";
       name = replaceExtensionToJpg(file.name);
     }
 
-    const { url } = await uploadImage(buffer, mimeType, name);
+    const { url } = await uploadImage(buffer, storeMime, name);
     return NextResponse.json({ url }, { status: 200 });
   } catch (error) {
     console.error("[upload]", error);

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { uploadImage } from "@/lib/storage";
 
+const MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
 export async function POST(request: Request) {
   const formData = await request.formData();
   const file = formData.get("image");
@@ -25,6 +27,16 @@ export async function POST(request: Request) {
         },
       },
       { status: 400 },
+    );
+  }
+
+  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+    return NextResponse.json(
+      {
+        data: null,
+        error: { message: "File is too large", code: "FILE_TOO_LARGE" },
+      },
+      { status: 413 },
     );
   }
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,7 +1,18 @@
 import { NextResponse } from "next/server";
-import { uploadImage } from "@/lib/storage";
+import { uploadImage, convertHeicToJpeg } from "@/lib/storage";
+import { HEIC_MIME_TYPES } from "@/types/upload";
 
 const MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+const HEIC_MIME_SET = new Set<string>(HEIC_MIME_TYPES);
+
+function isHeic(mimeType: string): boolean {
+  return HEIC_MIME_SET.has(mimeType.toLowerCase());
+}
+
+function replaceExtensionToJpg(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? `${name.slice(0, dot)}.jpg` : `${name}.jpg`;
+}
 
 export async function POST(request: Request) {
   const formData = await request.formData();
@@ -42,8 +53,18 @@ export async function POST(request: Request) {
 
   try {
     const bytes = await file.arrayBuffer();
-    const buffer = Buffer.from(bytes);
-    const { url } = await uploadImage(buffer, file.type, file.name);
+    let buffer: Buffer = Buffer.from(bytes);
+    let mimeType: string = file.type;
+    let name: string = file.name;
+
+    if (isHeic(file.type)) {
+      // ブラウザ表示互換のため HEIC/HEIF はサーバーサイドで JPEG 化してから保存。
+      buffer = await convertHeicToJpeg(buffer);
+      mimeType = "image/jpeg";
+      name = replaceExtensionToJpg(file.name);
+    }
+
+    const { url } = await uploadImage(buffer, mimeType, name);
     return NextResponse.json({ url }, { status: 200 });
   } catch (error) {
     console.error("[upload]", error);

--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ClockIcon, PlusIcon, UserIcon } from "@/components/ui/icons";
+import { CalendarIcon, PlusIcon, SearchIcon } from "@/components/ui/icons";
 
 export function BottomNav() {
   const pathname = usePathname();
@@ -25,9 +25,12 @@ export function BottomNav() {
           <Link
             href="/search"
             aria-label="着こなし検索"
-            className="flex h-14 w-14 items-center justify-center rounded-full bg-offwhite/80 backdrop-blur-md text-denim-dark shadow-lg ring-1 ring-denim/10 transition-all hover:bg-offwhite hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:bg-canvas-subtle/80 dark:text-offwhite dark:ring-offwhite/10"
+            className="flex h-14 w-14 flex-col items-center justify-center rounded-full bg-offwhite/80 backdrop-blur-md text-denim-dark shadow-lg ring-1 ring-denim/10 transition-all hover:bg-offwhite hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:bg-canvas-subtle/80 dark:text-offwhite dark:ring-offwhite/10"
           >
-            <ClockIcon width={24} height={24} />
+            <SearchIcon width={20} height={20} />
+            <span className="text-[9px] font-medium tracking-wider mt-0.5">
+              検索
+            </span>
           </Link>
 
           <Link
@@ -43,9 +46,9 @@ export function BottomNav() {
             aria-label="自分のOOTD一覧"
             className="flex h-14 w-14 flex-col items-center justify-center rounded-full bg-offwhite/80 backdrop-blur-md text-denim-dark shadow-lg ring-1 ring-denim/10 transition-all hover:bg-offwhite hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:bg-canvas-subtle/80 dark:text-offwhite dark:ring-offwhite/10"
           >
-            <UserIcon width={20} height={20} />
+            <CalendarIcon width={20} height={20} />
             <span className="text-[9px] font-medium tracking-wider mt-0.5">
-              自分
+              一覧
             </span>
           </Link>
         </div>

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -9,13 +9,27 @@ interface UploadResult {
   url: string;
 }
 
+interface SignedUploadUrlResult {
+  signedUrl: string;
+  path: string;
+  publicUrl: string;
+}
+
 const MIME_TO_EXT: Record<string, string> = {
   "image/jpeg": ".jpg",
   "image/jpg": ".jpg",
   "image/png": ".png",
   "image/gif": ".gif",
   "image/webp": ".webp",
+  "image/heic": ".heic",
+  "image/heif": ".heif",
 };
+
+/**
+ * 署名URLが有効でいてほしい上限秒数（ドキュメント目的）。
+ * Supabase 側の実装上は固定（約2時間）で、この値はクライアントへの目安。
+ */
+export const SIGNED_URL_EXPIRES_IN_SEC = 60;
 
 const SAFE_EXTENSION_PATTERN = /^\.[a-z0-9]{1,10}$/;
 
@@ -109,4 +123,73 @@ export async function uploadImage(
     return uploadSupabase(buffer, mimeType, originalName);
   }
   return uploadLocal(buffer, mimeType, originalName);
+}
+
+/**
+ * クライアント直接アップロード用の署名URLを発行する。
+ * 呼び出しは service_role 権限で行うため、RLS を緩める必要はない。
+ * - signedUrl: ブラウザから PUT する短期有効URL
+ * - path: バケット内オブジェクトパス
+ * - publicUrl: アップロード後にアプリで参照する公開URL
+ */
+export async function createSignedUploadUrl(
+  mimeType: string,
+  originalName: string,
+): Promise<SignedUploadUrlResult> {
+  const driver = resolveDriver();
+  if (driver !== "supabase") {
+    throw new Error(
+      "createSignedUploadUrl は STORAGE_DRIVER=supabase でのみ利用可能",
+    );
+  }
+
+  const bucket = process.env.SUPABASE_STORAGE_BUCKET;
+  if (!bucket) {
+    throw new Error(
+      "createSignedUploadUrl requires SUPABASE_STORAGE_BUCKET",
+    );
+  }
+
+  const client = getSupabaseClient();
+  const ext = resolveExtension(mimeType, originalName);
+  const path = `${randomUUID()}${ext}`;
+
+  // 注: Supabase の createSignedUploadUrl はサーバー側で固定の有効期限（約2時間）を
+  // 持つ。expiresIn の引数は受け付けない（v2 系仕様）。アプリ側の SLA としては
+  // SIGNED_URL_EXPIRES_IN_SEC を上限の目安としてドキュメント化しておくに留める。
+  const { data, error } = await client.storage
+    .from(bucket)
+    .createSignedUploadUrl(path);
+  if (error || !data) {
+    throw new Error(
+      `Failed to create signed upload URL: ${error?.message ?? "unknown"}`,
+    );
+  }
+
+  // 公開URLは我々が指定した path 基準で組み立てる。Supabase 側の echo を信用しすぎない。
+  const { data: publicData } = client.storage.from(bucket).getPublicUrl(path);
+  if (!publicData?.publicUrl) {
+    throw new Error("Public URL is missing after signed URL creation");
+  }
+
+  return {
+    signedUrl: data.signedUrl,
+    path,
+    publicUrl: publicData.publicUrl,
+  };
+}
+
+/**
+ * HEIC/HEIF Buffer を JPEG Buffer に変換する。pure JS 実装の heic-convert を使う。
+ * Vercel ランタイムで動かすため native 依存（libheif）を避けている。
+ */
+export async function convertHeicToJpeg(buffer: Buffer): Promise<Buffer> {
+  // 動的 import で cold-start 時の読み込みコストを限定する。
+  const { default: heicConvert } = await import("heic-convert");
+  const out = await heicConvert({
+    buffer,
+    format: "JPEG",
+    quality: 0.85,
+  });
+  return Buffer.from(out);
 }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,106 @@
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+type Driver = "local" | "supabase";
+
+interface UploadResult {
+  url: string;
+}
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/png": ".png",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+};
+
+function resolveExtension(mimeType: string, fallbackName: string): string {
+  const fromMime = MIME_TO_EXT[mimeType.toLowerCase()];
+  if (fromMime) return fromMime;
+  const dotIndex = fallbackName.lastIndexOf(".");
+  if (dotIndex >= 0 && dotIndex < fallbackName.length - 1) {
+    return fallbackName.slice(dotIndex);
+  }
+  return ".jpg";
+}
+
+function resolveDriver(): Driver {
+  const raw = process.env.STORAGE_DRIVER?.toLowerCase();
+  return raw === "supabase" ? "supabase" : "local";
+}
+
+async function uploadLocal(
+  buffer: Buffer,
+  mimeType: string,
+  originalName: string,
+): Promise<UploadResult> {
+  const ext = resolveExtension(mimeType, originalName);
+  const filename = `${randomUUID()}${ext}`;
+  const uploadsDir = join(process.cwd(), "public", "uploads");
+  await mkdir(uploadsDir, { recursive: true });
+  await writeFile(join(uploadsDir, filename), buffer);
+  return { url: `/uploads/${filename}` };
+}
+
+let cachedSupabase: SupabaseClient | null = null;
+
+function getSupabaseClient(): SupabaseClient {
+  if (cachedSupabase) return cachedSupabase;
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      "STORAGE_DRIVER=supabase requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY",
+    );
+  }
+
+  cachedSupabase = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  return cachedSupabase;
+}
+
+async function uploadSupabase(
+  buffer: Buffer,
+  mimeType: string,
+  originalName: string,
+): Promise<UploadResult> {
+  const bucket = process.env.SUPABASE_STORAGE_BUCKET;
+  if (!bucket) {
+    throw new Error("STORAGE_DRIVER=supabase requires SUPABASE_STORAGE_BUCKET");
+  }
+
+  const client = getSupabaseClient();
+  const ext = resolveExtension(mimeType, originalName);
+  const path = `${randomUUID()}${ext}`;
+
+  const { error } = await client.storage.from(bucket).upload(path, buffer, {
+    contentType: mimeType,
+    upsert: false,
+  });
+  if (error) {
+    throw new Error(`Supabase upload failed: ${error.message}`);
+  }
+
+  const { data } = client.storage.from(bucket).getPublicUrl(path);
+  if (!data?.publicUrl) {
+    throw new Error("Supabase public URL is missing");
+  }
+  return { url: data.publicUrl };
+}
+
+export async function uploadImage(
+  buffer: Buffer,
+  mimeType: string,
+  originalName: string,
+): Promise<UploadResult> {
+  const driver = resolveDriver();
+  if (driver === "supabase") {
+    return uploadSupabase(buffer, mimeType, originalName);
+  }
+  return uploadLocal(buffer, mimeType, originalName);
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -17,19 +17,25 @@ const MIME_TO_EXT: Record<string, string> = {
   "image/webp": ".webp",
 };
 
+const SAFE_EXTENSION_PATTERN = /^\.[a-z0-9]{1,10}$/;
+
 function resolveExtension(mimeType: string, fallbackName: string): string {
   const fromMime = MIME_TO_EXT[mimeType.toLowerCase()];
   if (fromMime) return fromMime;
   const dotIndex = fallbackName.lastIndexOf(".");
   if (dotIndex >= 0 && dotIndex < fallbackName.length - 1) {
-    return fallbackName.slice(dotIndex);
+    const candidate = fallbackName.slice(dotIndex).toLowerCase();
+    if (SAFE_EXTENSION_PATTERN.test(candidate)) return candidate;
   }
   return ".jpg";
 }
 
 function resolveDriver(): Driver {
-  const raw = process.env.STORAGE_DRIVER?.toLowerCase();
-  return raw === "supabase" ? "supabase" : "local";
+  const raw = process.env.STORAGE_DRIVER?.toLowerCase() ?? "local";
+  if (raw === "local" || raw === "supabase") return raw;
+  throw new Error(
+    `Invalid STORAGE_DRIVER="${raw}". Allowed values are "local" or "supabase".`,
+  );
 }
 
 async function uploadLocal(

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@google/generative-ai": "^0.24.1",
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
+        "@supabase/supabase-js": "^2.105.1",
         "@tanstack/react-query": "^5.99.0",
         "next": "^16.2.3",
         "pg": "^8.20.0",
@@ -2365,6 +2366,92 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.1.tgz",
+      "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.1.tgz",
+      "integrity": "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.1.tgz",
+      "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.1.tgz",
+      "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.1",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.1.tgz",
+      "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.1.tgz",
+      "integrity": "sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.1",
+        "@supabase/functions-js": "2.105.1",
+        "@supabase/postgrest-js": "2.105.1",
+        "@supabase/realtime-js": "2.105.1",
+        "@supabase/storage-js": "2.105.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -3028,6 +3115,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/jest": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -6198,6 +6294,15 @@
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -10335,6 +10440,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@prisma/client": "^7.7.0",
         "@supabase/supabase-js": "^2.105.1",
         "@tanstack/react-query": "^5.99.0",
+        "heic-convert": "^2.1.0",
         "next": "^16.2.3",
         "pg": "^8.20.0",
         "react": "^19.0.0",
@@ -6248,6 +6249,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/heic-convert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-2.1.0.tgz",
+      "integrity": "sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==",
+      "license": "ISC",
+      "dependencies": {
+        "heic-decode": "^2.0.0",
+        "jpeg-js": "^0.4.4",
+        "pngjs": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/heic-decode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.1.0.tgz",
+      "integrity": "sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==",
+      "license": "ISC",
+      "dependencies": {
+        "libheif-js": "^1.19.8"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -7077,6 +7104,12 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7252,6 +7285,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libheif-js": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.19.8.tgz",
+      "integrity": "sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/lightningcss": {
@@ -8348,6 +8390,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "e2e": "playwright test",
+    "smoke:storage": "node scripts/smoke-supabase-storage.mjs",
     "postinstall": "prisma generate"
   },
   "dependencies": {
@@ -19,6 +20,7 @@
     "@prisma/client": "^7.7.0",
     "@supabase/supabase-js": "^2.105.1",
     "@tanstack/react-query": "^5.99.0",
+    "heic-convert": "^2.1.0",
     "next": "^16.2.3",
     "pg": "^8.20.0",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@google/generative-ai": "^0.24.1",
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
+    "@supabase/supabase-js": "^2.105.1",
     "@tanstack/react-query": "^5.99.0",
     "next": "^16.2.3",
     "pg": "^8.20.0",

--- a/scripts/smoke-supabase-storage.mjs
+++ b/scripts/smoke-supabase-storage.mjs
@@ -1,0 +1,115 @@
+/**
+ * Supabase Storage 疎通スモークテスト（ESM版・tsx不要）
+ *
+ * 使い方: node scripts/smoke-supabase-storage.mjs
+ *
+ * 検証内容:
+ *   1. .env.local の必須環境変数チェック
+ *   2. Supabase Storage に PNG をアップロード
+ *   3. 公開URLで取得できることを確認
+ *   4. テストファイルを削除
+ */
+
+import { config } from "dotenv";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { createClient } from "@supabase/supabase-js";
+
+const envPath = join(process.cwd(), ".env.local");
+if (!existsSync(envPath)) {
+  console.error("[FAIL] .env.local が見つからない");
+  process.exit(1);
+}
+config({ path: envPath });
+
+const REQUIRED = [
+  "STORAGE_DRIVER",
+  "SUPABASE_URL",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "SUPABASE_STORAGE_BUCKET",
+];
+
+function assertEnvs() {
+  const missing = REQUIRED.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    console.error(`[FAIL] missing env: ${missing.join(", ")}`);
+    process.exit(1);
+  }
+  if (process.env.STORAGE_DRIVER !== "supabase") {
+    console.error(
+      `[FAIL] STORAGE_DRIVER は "supabase" を期待。現値: "${process.env.STORAGE_DRIVER}"`,
+    );
+    process.exit(1);
+  }
+  console.log("[OK] env 4件揃ってる / STORAGE_DRIVER=supabase");
+}
+
+// 1x1 透明 PNG
+const PNG_1x1 = Buffer.from(
+  "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000D49444154789C636400000000050001A5F645400000000049454E44AE426082",
+  "hex",
+);
+
+async function main() {
+  assertEnvs();
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+  const bucket = process.env.SUPABASE_STORAGE_BUCKET;
+  const path = `smoke-${randomUUID()}.png`;
+
+  console.log(`[..] アップロード: bucket=${bucket} path=${path}`);
+  const { error: upErr } = await supabase.storage
+    .from(bucket)
+    .upload(path, PNG_1x1, {
+      contentType: "image/png",
+      upsert: false,
+    });
+  if (upErr) {
+    console.error(`[FAIL] upload: ${upErr.message}`);
+    process.exit(1);
+  }
+  console.log("[OK] アップロード成功");
+
+  const { data: urlData } = supabase.storage.from(bucket).getPublicUrl(path);
+  const publicUrl = urlData?.publicUrl;
+  if (!publicUrl) {
+    console.error("[FAIL] publicUrl 取得失敗");
+    process.exit(1);
+  }
+  console.log(`[OK] publicUrl: ${publicUrl}`);
+
+  console.log("[..] HTTP GET");
+  const res = await fetch(publicUrl);
+  if (!res.ok) {
+    console.error(`[FAIL] GET: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.length !== PNG_1x1.length) {
+    console.error(
+      `[FAIL] バイト長不一致: expected=${PNG_1x1.length}, actual=${buf.length}`,
+    );
+    process.exit(1);
+  }
+  console.log(`[OK] 公開URL取得成功 (${buf.length} bytes)`);
+
+  console.log("[..] テストファイル削除");
+  const { error: rmErr } = await supabase.storage.from(bucket).remove([path]);
+  if (rmErr) {
+    console.warn(`[WARN] 削除失敗: ${rmErr.message}（手動削除が必要）`);
+  } else {
+    console.log("[OK] テストファイル削除完了");
+  }
+
+  console.log("\n[PASS] Supabase Storage 疎通OK");
+}
+
+main().catch((e) => {
+  console.error("[FAIL]", e);
+  process.exit(1);
+});

--- a/scripts/smoke-supabase-storage.mjs
+++ b/scripts/smoke-supabase-storage.mjs
@@ -89,6 +89,11 @@ async function main() {
     console.error(`[FAIL] GET: ${res.status} ${res.statusText}`);
     process.exit(1);
   }
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().startsWith("image/png")) {
+    console.error(`[FAIL] content-type 不正: "${contentType}"（image/png 期待）`);
+    process.exit(1);
+  }
   const buf = Buffer.from(await res.arrayBuffer());
   if (buf.length !== PNG_1x1.length) {
     console.error(

--- a/tests/unit/api/upload-url.test.ts
+++ b/tests/unit/api/upload-url.test.ts
@@ -27,6 +27,20 @@ function makeRequest(body: unknown): Request {
 }
 
 describe("POST /api/upload-url", () => {
+  it("不正な JSON ボディなら 400 VALIDATION_ERROR を返し、createSignedUploadUrl を呼ばない", async () => {
+    const req = new Request("http://localhost/api/upload-url", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const json = (await res.json()) as { error?: { code?: string } };
+    expect(json.error?.code).toBe("VALIDATION_ERROR");
+    expect(createSignedUploadUrlMock).not.toHaveBeenCalled();
+  });
+
   it("有効な入力で 200 と署名URLを返す", async () => {
     createSignedUploadUrlMock.mockResolvedValue({
       signedUrl: "https://x/sign?token=t",

--- a/tests/unit/api/upload-url.test.ts
+++ b/tests/unit/api/upload-url.test.ts
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------
+// /api/upload-url Route Handler の振る舞いを検証する。
+// - POST {mimeType, originalName} -> 200 {signedUrl, path, publicUrl}
+// - 不正な mimeType -> 400 VALIDATION_ERROR
+// - 内部例外 -> 500 INTERNAL_ERROR（スタックトレースを返さないこと）
+// ---------------------------------------------------------------------------
+
+const createSignedUploadUrlMock = vi.fn();
+
+vi.mock("@/lib/storage", () => ({
+  createSignedUploadUrl: (...args: unknown[]) =>
+    createSignedUploadUrlMock(...args),
+}));
+
+import { POST } from "@/app/api/upload-url/route";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/upload-url", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/upload-url", () => {
+  it("有効な入力で 200 と署名URLを返す", async () => {
+    createSignedUploadUrlMock.mockResolvedValue({
+      signedUrl: "https://x/sign?token=t",
+      path: "abc.jpg",
+      publicUrl: "https://x/public/abc.jpg",
+    });
+
+    const res = await POST(
+      makeRequest({ mimeType: "image/jpeg", originalName: "abc.jpg" }),
+    );
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as {
+      signedUrl?: string;
+      path?: string;
+      publicUrl?: string;
+    };
+    expect(json.signedUrl).toContain("token=");
+    expect(json.path).toBe("abc.jpg");
+    expect(json.publicUrl).toBe("https://x/public/abc.jpg");
+  });
+
+  it("HEIC のような未対応 mimeType は 400 を返す", async () => {
+    const res = await POST(
+      makeRequest({ mimeType: "image/heic", originalName: "p.heic" }),
+    );
+    expect(res.status).toBe(400);
+
+    const json = (await res.json()) as {
+      error?: { code?: string };
+    };
+    expect(json.error?.code).toBe("VALIDATION_ERROR");
+    expect(createSignedUploadUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("originalName が空でも 400 を返す", async () => {
+    const res = await POST(
+      makeRequest({ mimeType: "image/jpeg", originalName: "" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("内部例外時は 500 を返し、スタックトレースを露出しない", async () => {
+    createSignedUploadUrlMock.mockRejectedValue(
+      new Error("internal-detail-leak"),
+    );
+
+    const res = await POST(
+      makeRequest({ mimeType: "image/jpeg", originalName: "abc.jpg" }),
+    );
+    expect(res.status).toBe(500);
+
+    const json = (await res.json()) as {
+      error?: { code?: string; message?: string };
+    };
+    expect(json.error?.code).toBe("INTERNAL_ERROR");
+    expect(json.error?.message).not.toContain("internal-detail-leak");
+  });
+});

--- a/tests/unit/api/upload.test.ts
+++ b/tests/unit/api/upload.test.ts
@@ -36,7 +36,9 @@ describe("POST /api/upload — HEIC 経路", () => {
   it("HEIC を受けたら convertHeicToJpeg で変換した Buffer を image/jpeg として保存する", async () => {
     const converted = Buffer.from("jpeg-bytes");
     convertHeicToJpegMock.mockResolvedValue(converted);
-    uploadImageMock.mockResolvedValue({ url: "https://x/public/converted.jpg" });
+    uploadImageMock.mockResolvedValue({
+      url: "https://x/public/converted.jpg",
+    });
 
     const heic = new File([new Uint8Array([0, 1, 2, 3])], "photo.heic", {
       type: "image/heic",
@@ -80,6 +82,36 @@ describe("POST /api/upload — HEIC 経路", () => {
       "image/jpeg",
       "a.jpg",
     );
+  });
+
+  it("10MB を超えるファイルは 413 FILE_TOO_LARGE を返し、uploadImage を呼ばない", async () => {
+    // 11MB の Uint8Array を File に詰める。File.size はバイト長で判定される。
+    const oversize = new Uint8Array(11 * 1024 * 1024);
+    const big = new File([oversize], "huge.jpg", { type: "image/jpeg" });
+
+    const res = await POST(makeFormDataRequest(big));
+
+    expect(res.status).toBe(413);
+    const json = (await res.json()) as {
+      data: unknown;
+      error?: { code?: string };
+    };
+    expect(json.data).toBeNull();
+    expect(json.error?.code).toBe("FILE_TOO_LARGE");
+    expect(uploadImageMock).not.toHaveBeenCalled();
+    expect(convertHeicToJpegMock).not.toHaveBeenCalled();
+  });
+
+  it("image/svg+xml のような未許可 MIME は 400 を返し、uploadImage を呼ばない", async () => {
+    const svg = new File([new Uint8Array([0])], "evil.svg", {
+      type: "image/svg+xml",
+    });
+    const res = await POST(makeFormDataRequest(svg));
+
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: { code?: string } };
+    expect(json.error?.code).toBe("INVALID_FILE_TYPE");
+    expect(uploadImageMock).not.toHaveBeenCalled();
   });
 
   it("HEIC 変換失敗時は 500 を返し、内部エラーメッセージを露出しない", async () => {

--- a/tests/unit/api/upload.test.ts
+++ b/tests/unit/api/upload.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+// ---------------------------------------------------------------------------
+// /api/upload Route Handler の HEIC 経路を検証する。
+// - HEIC/HEIF: convertHeicToJpeg を呼んで JPEG として保存し、URL を返す
+// - JPEG/PNG: 従来通り uploadImage に直接渡す
+//
+// 環境: Route Handler は Node ランタイムを前提とするため jsdom ではなく node 環境で
+// 検証する。jsdom の File/Blob/FormData は undici の実装と別物で `instanceof File`
+// が false になりルートが 400 を返してしまうため。
+// ---------------------------------------------------------------------------
+
+const uploadImageMock = vi.fn();
+const convertHeicToJpegMock = vi.fn();
+
+vi.mock("@/lib/storage", () => ({
+  uploadImage: (...args: unknown[]) => uploadImageMock(...args),
+  convertHeicToJpeg: (...args: unknown[]) => convertHeicToJpegMock(...args),
+}));
+
+import { POST } from "@/app/api/upload/route";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeFormDataRequest(file: File): Request {
+  const fd = new FormData();
+  fd.append("image", file);
+  return new Request("http://localhost/api/upload", {
+    method: "POST",
+    body: fd,
+  });
+}
+
+describe("POST /api/upload — HEIC 経路", () => {
+  it("HEIC を受けたら convertHeicToJpeg で変換した Buffer を image/jpeg として保存する", async () => {
+    const converted = Buffer.from("jpeg-bytes");
+    convertHeicToJpegMock.mockResolvedValue(converted);
+    uploadImageMock.mockResolvedValue({ url: "https://x/public/converted.jpg" });
+
+    const heic = new File([new Uint8Array([0, 1, 2, 3])], "photo.heic", {
+      type: "image/heic",
+    });
+    const res = await POST(makeFormDataRequest(heic));
+
+    expect(res.status).toBe(200);
+    expect(convertHeicToJpegMock).toHaveBeenCalled();
+    // uploadImage は変換後 Buffer / image/jpeg / .jpg 拡張子で呼ばれる
+    const [bufArg, mimeArg, nameArg] = uploadImageMock.mock.calls[0] ?? [];
+    expect(Buffer.isBuffer(bufArg)).toBe(true);
+    expect(mimeArg).toBe("image/jpeg");
+    expect(nameArg).toMatch(/\.jpg$/);
+  });
+
+  it("HEIF も同様に JPEG 変換経路に乗る", async () => {
+    convertHeicToJpegMock.mockResolvedValue(Buffer.from("ok"));
+    uploadImageMock.mockResolvedValue({ url: "https://x/public/x.jpg" });
+
+    const heif = new File([new Uint8Array([0])], "photo.heif", {
+      type: "image/heif",
+    });
+    const res = await POST(makeFormDataRequest(heif));
+
+    expect(res.status).toBe(200);
+    expect(convertHeicToJpegMock).toHaveBeenCalled();
+  });
+
+  it("JPEG は変換せずに直接 uploadImage に渡す", async () => {
+    uploadImageMock.mockResolvedValue({ url: "https://x/public/a.jpg" });
+
+    const jpeg = new File([new Uint8Array([0])], "a.jpg", {
+      type: "image/jpeg",
+    });
+    const res = await POST(makeFormDataRequest(jpeg));
+
+    expect(res.status).toBe(200);
+    expect(convertHeicToJpegMock).not.toHaveBeenCalled();
+    expect(uploadImageMock).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "image/jpeg",
+      "a.jpg",
+    );
+  });
+
+  it("HEIC 変換失敗時は 500 を返し、内部エラーメッセージを露出しない", async () => {
+    convertHeicToJpegMock.mockRejectedValue(new Error("libheif-secret"));
+
+    const heic = new File([new Uint8Array([0])], "p.heic", {
+      type: "image/heic",
+    });
+    const res = await POST(makeFormDataRequest(heic));
+
+    expect(res.status).toBe(500);
+    const json = (await res.json()) as {
+      error?: { code?: string; message?: string };
+    };
+    expect(json.error?.code).toBe("INTERNAL_ERROR");
+    expect(json.error?.message).not.toContain("libheif-secret");
+  });
+});

--- a/tests/unit/components/BottomNav.test.tsx
+++ b/tests/unit/components/BottomNav.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { BottomNav } from "@/components/ui/BottomNav";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/ootd",
+}));
+
+describe("BottomNav", () => {
+  it("着こなし検索リンクは /search を指し、search アイコンを表示する", () => {
+    render(<BottomNav />);
+    const link = screen.getByRole("link", { name: /着こなし検索/ });
+    expect(link).toHaveAttribute("href", "/search");
+    // SearchIcon は <circle> + <line> を持つ虫眼鏡アイコン
+    const svg = link.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.querySelector("circle")).not.toBeNull();
+  });
+
+  it("OOTD一覧リンクは /ootd を指し、calendar アイコンを表示する", () => {
+    render(<BottomNav />);
+    const link = screen.getByRole("link", { name: /OOTD一覧/ });
+    expect(link).toHaveAttribute("href", "/ootd");
+    // CalendarIcon は <rect> を持つ
+    const svg = link.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.querySelector("rect")).not.toBeNull();
+  });
+
+  it("OOTD追加（中央）リンクは /ootd/new を指す", () => {
+    render(<BottomNav />);
+    const link = screen.getByRole("link", { name: /OOTDを追加/ });
+    expect(link).toHaveAttribute("href", "/ootd/new");
+  });
+});

--- a/tests/unit/components/BottomNav.test.tsx
+++ b/tests/unit/components/BottomNav.test.tsx
@@ -1,11 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import { BottomNav } from "@/components/ui/BottomNav";
 
+const usePathnameMock = vi.fn();
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/ootd",
+  usePathname: () => usePathnameMock(),
 }));
 
 describe("BottomNav", () => {
+  beforeEach(() => {
+    usePathnameMock.mockReset();
+    usePathnameMock.mockReturnValue("/ootd");
+  });
+
   it("着こなし検索リンクは /search を指し、search アイコンを表示する", () => {
     render(<BottomNav />);
     const link = screen.getByRole("link", { name: /着こなし検索/ });
@@ -30,5 +36,17 @@ describe("BottomNav", () => {
     render(<BottomNav />);
     const link = screen.getByRole("link", { name: /OOTDを追加/ });
     expect(link).toHaveAttribute("href", "/ootd/new");
+  });
+
+  it("/ootd/new ではナビが描画されない（早期リターン）", () => {
+    usePathnameMock.mockReturnValue("/ootd/new");
+    const { container } = render(<BottomNav />);
+    expect(container.querySelector("nav")).toBeNull();
+  });
+
+  it("/ootd/new/foo（サブパス）でもナビは描画されない", () => {
+    usePathnameMock.mockReturnValue("/ootd/new/foo");
+    const { container } = render(<BottomNav />);
+    expect(container.querySelector("nav")).toBeNull();
   });
 });

--- a/tests/unit/components/OotdNewPageClient.test.tsx
+++ b/tests/unit/components/OotdNewPageClient.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+
+// useRouter / Server Action / useIsMobile を差し替えてレンダリング可能にする。
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("@/app/actions/ootd", () => ({
+  createOotdAction: vi.fn(),
+}));
+
+const useIsMobileMock = vi.fn();
+vi.mock("@/hooks/useIsMobile", () => ({
+  useIsMobile: () => useIsMobileMock(),
+}));
+
+import { OotdNewPageClient } from "@/app/(public)/ootd/new/OotdNewPageClient";
+
+function getFileInput(): HTMLInputElement {
+  const input = screen.getByLabelText("コーデ画像", { selector: "input" });
+  expect(input.tagName).toBe("INPUT");
+  return input as HTMLInputElement;
+}
+
+describe("OotdNewPageClient — capture 属性", () => {
+  beforeEach(() => {
+    useIsMobileMock.mockReset();
+  });
+
+  it("SP（isMobile=true）のとき file input に capture='environment' が付く", () => {
+    useIsMobileMock.mockReturnValue(true);
+    render(<OotdNewPageClient />);
+    expect(getFileInput().getAttribute("capture")).toBe("environment");
+  });
+
+  it("PC（isMobile=false）のとき file input に capture 属性が付かない", () => {
+    useIsMobileMock.mockReturnValue(false);
+    render(<OotdNewPageClient />);
+    expect(getFileInput().hasAttribute("capture")).toBe(false);
+  });
+});

--- a/tests/unit/components/OotdNewPageClient.upload.test.tsx
+++ b/tests/unit/components/OotdNewPageClient.upload.test.tsx
@@ -1,0 +1,132 @@
+// ---------------------------------------------------------------------------
+// OotdNewPageClient のアップロード経路分岐を検証する。
+// - JPEG/PNG/WebP/GIF: /api/upload-url を取得 → 署名URLへ直接 PUT → publicUrl を保持
+// - HEIC/HEIF: /api/upload に FormData を送る既存経路
+// ---------------------------------------------------------------------------
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("@/app/actions/ootd", () => ({
+  createOotdAction: vi.fn(),
+}));
+
+vi.mock("@/hooks/useIsMobile", () => ({
+  useIsMobile: () => false,
+}));
+
+import { OotdNewPageClient } from "@/app/(public)/ootd/new/OotdNewPageClient";
+
+function getFileInput(): HTMLInputElement {
+  const input = screen.getByLabelText("コーデ画像", { selector: "input" });
+  return input as HTMLInputElement;
+}
+
+function fakeFetchResponse(body: unknown, init?: { status?: number }): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("OotdNewPageClient — アップロード経路分岐", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("JPEG 選択時は /api/upload-url → 署名URLへ PUT → publicUrl を保持する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async (input: RequestInfo) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : (input as Request).url;
+        expect(url).toMatch(/\/api\/upload-url$/);
+        return fakeFetchResponse({
+          signedUrl: "https://x.supabase.co/sign?token=abc",
+          path: "abc.jpg",
+          publicUrl: "https://x.supabase.co/public/abc.jpg",
+        });
+      })
+      .mockImplementationOnce(async (input: RequestInfo, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : (input as Request).url;
+        expect(url).toContain("token=");
+        expect(init?.method).toBe("PUT");
+        return new Response(null, { status: 200 });
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<OotdNewPageClient />);
+    const file = new File([new Uint8Array([0, 1, 2])], "test.jpg", {
+      type: "image/jpeg",
+    });
+    fireEvent.change(getFileInput(), { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    // /api/upload は呼ばれない
+    const calledUrls = fetchMock.mock.calls.map((c) =>
+      typeof c[0] === "string" ? c[0] : (c[0] as Request).url,
+    );
+    expect(calledUrls.some((u) => u.endsWith("/api/upload"))).toBe(false);
+  });
+
+  it("HEIC 選択時は /api/upload に FormData を送る既存経路を使う", async () => {
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo) => {
+      const url =
+        typeof input === "string" ? input : (input as Request).url;
+      expect(url).toMatch(/\/api\/upload$/);
+      return fakeFetchResponse({ url: "https://x.supabase.co/public/p.jpg" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<OotdNewPageClient />);
+    const heic = new File([new Uint8Array([0])], "photo.heic", {
+      type: "image/heic",
+    });
+    fireEvent.change(getFileInput(), { target: { files: [heic] } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // /api/upload-url は呼ばれない
+    const calledUrls = fetchMock.mock.calls.map((c) =>
+      typeof c[0] === "string" ? c[0] : (c[0] as Request).url,
+    );
+    expect(calledUrls.some((u) => u.endsWith("/api/upload-url"))).toBe(false);
+  });
+
+  it("署名URLへの PUT が失敗したらエラーメッセージを表示する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        fakeFetchResponse({
+          signedUrl: "https://x/sign?token=t",
+          path: "p.jpg",
+          publicUrl: "https://x/public/p.jpg",
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 403 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<OotdNewPageClient />);
+    const jpeg = new File([new Uint8Array([0])], "x.jpg", {
+      type: "image/jpeg",
+    });
+    fireEvent.change(getFileInput(), { target: { files: [jpeg] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/components/OotdNewPageClient.upload.test.tsx
+++ b/tests/unit/components/OotdNewPageClient.upload.test.tsx
@@ -25,7 +25,10 @@ function getFileInput(): HTMLInputElement {
   return input as HTMLInputElement;
 }
 
-function fakeFetchResponse(body: unknown, init?: { status?: number }): Response {
+function fakeFetchResponse(
+  body: unknown,
+  init?: { status?: number },
+): Response {
   return new Response(JSON.stringify(body), {
     status: init?.status ?? 200,
     headers: { "Content-Type": "application/json" },
@@ -40,27 +43,35 @@ describe("OotdNewPageClient — アップロード経路分岐", () => {
   it("JPEG 選択時は /api/upload-url → 署名URLへ PUT → publicUrl を保持する", async () => {
     const fetchMock = vi
       .fn()
-      .mockImplementationOnce(async (input: RequestInfo) => {
-        const url =
-          typeof input === "string"
-            ? input
-            : (input as Request).url;
-        expect(url).toMatch(/\/api\/upload-url$/);
-        return fakeFetchResponse({
-          signedUrl: "https://x.supabase.co/sign?token=abc",
-          path: "abc.jpg",
-          publicUrl: "https://x.supabase.co/public/abc.jpg",
-        });
-      })
-      .mockImplementationOnce(async (input: RequestInfo, init?: RequestInit) => {
-        const url =
-          typeof input === "string"
-            ? input
-            : (input as Request).url;
-        expect(url).toContain("token=");
-        expect(init?.method).toBe("PUT");
-        return new Response(null, { status: 200 });
-      });
+      .mockImplementationOnce(
+        async (input: RequestInfo, init?: RequestInit) => {
+          const url =
+            typeof input === "string" ? input : (input as Request).url;
+          expect(url).toMatch(/\/api\/upload-url$/);
+          // クライアント→API の契約検証: POST + {mimeType, originalName}
+          expect(init?.method).toBe("POST");
+          const parsed = JSON.parse(String(init?.body ?? "{}")) as {
+            mimeType?: string;
+            originalName?: string;
+          };
+          expect(parsed.mimeType).toBe("image/jpeg");
+          expect(parsed.originalName).toBe("test.jpg");
+          return fakeFetchResponse({
+            signedUrl: "https://x.supabase.co/sign?token=abc",
+            path: "abc.jpg",
+            publicUrl: "https://x.supabase.co/public/abc.jpg",
+          });
+        },
+      )
+      .mockImplementationOnce(
+        async (input: RequestInfo, init?: RequestInit) => {
+          const url =
+            typeof input === "string" ? input : (input as Request).url;
+          expect(url).toContain("token=");
+          expect(init?.method).toBe("PUT");
+          return new Response(null, { status: 200 });
+        },
+      );
     vi.stubGlobal("fetch", fetchMock);
 
     render(<OotdNewPageClient />);
@@ -82,8 +93,7 @@ describe("OotdNewPageClient — アップロード経路分岐", () => {
 
   it("HEIC 選択時は /api/upload に FormData を送る既存経路を使う", async () => {
     const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo) => {
-      const url =
-        typeof input === "string" ? input : (input as Request).url;
+      const url = typeof input === "string" ? input : (input as Request).url;
       expect(url).toMatch(/\/api\/upload$/);
       return fakeFetchResponse({ url: "https://x.supabase.co/public/p.jpg" });
     });

--- a/tests/unit/services/storage.test.ts
+++ b/tests/unit/services/storage.test.ts
@@ -1,0 +1,143 @@
+import { writeFile, mkdir, unlink } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ---------------------------------------------------------------------------
+// lib/storage の振る舞いを検証する。
+// - driver=local（既定）: public/uploads/ にファイルを書き出して /uploads/<filename> を返す
+// - driver=supabase: Supabase Storage クライアントの upload を呼んで public URL を返す
+// ---------------------------------------------------------------------------
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "@supabase/supabase-js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("uploadImage (local driver)", () => {
+  it("STORAGE_DRIVER 未設定または 'local' のときローカルに保存する", async () => {
+    process.env.STORAGE_DRIVER = "local";
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    const { uploadImage } = await import("@/lib/storage");
+    const buffer = Buffer.from("dummy-image-bytes");
+
+    const result = await uploadImage(buffer, "image/jpeg", "test.jpg");
+
+    expect(result.url).toMatch(/^\/uploads\/[^/]+\.jpg$/);
+  });
+
+  it("拡張子を mimeType から推測する", async () => {
+    process.env.STORAGE_DRIVER = "local";
+
+    const { uploadImage } = await import("@/lib/storage");
+    const buffer = Buffer.from("dummy");
+
+    const result = await uploadImage(buffer, "image/png", "noext");
+
+    expect(result.url).toMatch(/\.png$/);
+  });
+});
+
+describe("uploadImage (supabase driver)", () => {
+  it("STORAGE_DRIVER='supabase' のとき Supabase に upload する", async () => {
+    process.env.STORAGE_DRIVER = "supabase";
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+    process.env.SUPABASE_STORAGE_BUCKET = "ootd-images";
+
+    const upload = vi
+      .fn()
+      .mockResolvedValue({ data: { path: "abc.jpg" }, error: null });
+    const getPublicUrl = vi.fn().mockReturnValue({
+      data: {
+        publicUrl:
+          "https://example.supabase.co/storage/v1/object/public/ootd-images/abc.jpg",
+      },
+    });
+    const from = vi.fn().mockReturnValue({ upload, getPublicUrl });
+
+    vi.mocked(createClient).mockReturnValue({ storage: { from } } as never);
+
+    const { uploadImage } = await import("@/lib/storage");
+    const buffer = Buffer.from("dummy");
+
+    const result = await uploadImage(buffer, "image/jpeg", "abc.jpg");
+
+    expect(createClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "service-role-key",
+      expect.any(Object),
+    );
+    expect(from).toHaveBeenCalledWith("ootd-images");
+    expect(upload).toHaveBeenCalled();
+    expect(result.url).toBe(
+      "https://example.supabase.co/storage/v1/object/public/ootd-images/abc.jpg",
+    );
+  });
+
+  it("Supabase upload がエラーを返したら例外を投げる", async () => {
+    process.env.STORAGE_DRIVER = "supabase";
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+    process.env.SUPABASE_STORAGE_BUCKET = "ootd-images";
+
+    const upload = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "boom" } });
+    const from = vi.fn().mockReturnValue({ upload, getPublicUrl: vi.fn() });
+    vi.mocked(createClient).mockReturnValue({ storage: { from } } as never);
+
+    const { uploadImage } = await import("@/lib/storage");
+    const buffer = Buffer.from("dummy");
+
+    await expect(
+      uploadImage(buffer, "image/jpeg", "abc.jpg"),
+    ).rejects.toThrow();
+  });
+
+  it("STORAGE_DRIVER='supabase' でも Supabase の env が無いと例外を投げる", async () => {
+    process.env.STORAGE_DRIVER = "supabase";
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    const { uploadImage } = await import("@/lib/storage");
+    const buffer = Buffer.from("dummy");
+
+    await expect(
+      uploadImage(buffer, "image/jpeg", "abc.jpg"),
+    ).rejects.toThrow();
+  });
+});
+
+// 後始末: ローカルテスト用に作られたファイルが残っても次回テストには影響しないが、
+// 大量に蓄積しないように tests 内で参照しないことを確認。
+describe("local driver の副作用", () => {
+  it("public/uploads/ 配下に書き出す", async () => {
+    process.env.STORAGE_DRIVER = "local";
+
+    const { uploadImage } = await import("@/lib/storage");
+    const buffer = Buffer.from("hello");
+
+    const result = await uploadImage(buffer, "image/jpeg", "x.jpg");
+    expect(result.url.startsWith("/uploads/")).toBe(true);
+  });
+});
+
+// helper: テストの後始末で生成された /public/uploads/*.jpg が増えないように
+// uploadImage を呼ぶ際は random filename になる前提だが、テストで作ったファイルを
+// 全削除すると並列実行時に他テストを壊す可能性があるため放置（CI ではクリーンビルド）。
+void writeFile;
+void mkdir;
+void unlink;
+void join;
+void tmpdir;

--- a/tests/unit/services/storage.test.ts
+++ b/tests/unit/services/storage.test.ts
@@ -1,17 +1,27 @@
-import { writeFile, mkdir, unlink } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
-
 // ---------------------------------------------------------------------------
 // lib/storage の振る舞いを検証する。
 // - driver=local（既定）: public/uploads/ にファイルを書き出して /uploads/<filename> を返す
 // - driver=supabase: Supabase Storage クライアントの upload を呼んで public URL を返す
+//
+// 注: fs/promises は外部 I/O のためモック許可（testing.md の例外条項に倣う）。
+// 実 FS への書き込みは E2E ではなく実機検証で担保する。
 // ---------------------------------------------------------------------------
+
+vi.mock("fs/promises", () => {
+  const writeFile = vi.fn().mockResolvedValue(undefined);
+  const mkdir = vi.fn().mockResolvedValue(undefined);
+  return {
+    default: { writeFile, mkdir },
+    writeFile,
+    mkdir,
+  };
+});
 
 vi.mock("@supabase/supabase-js", () => ({
   createClient: vi.fn(),
 }));
 
+import { writeFile, mkdir } from "fs/promises";
 import { createClient } from "@supabase/supabase-js";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -34,6 +44,8 @@ describe("uploadImage (local driver)", () => {
     const result = await uploadImage(buffer, "image/jpeg", "test.jpg");
 
     expect(result.url).toMatch(/^\/uploads\/[^/]+\.jpg$/);
+    expect(mkdir).toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalled();
   });
 
   it("拡張子を mimeType から推測する", async () => {
@@ -45,6 +57,22 @@ describe("uploadImage (local driver)", () => {
     const result = await uploadImage(buffer, "image/png", "noext");
 
     expect(result.url).toMatch(/\.png$/);
+  });
+
+  it("不正な拡張子（パス区切りや特殊文字混入）は .jpg にフォールバックする", async () => {
+    process.env.STORAGE_DRIVER = "local";
+
+    const { uploadImage } = await import("@/lib/storage");
+    const buffer = Buffer.from("dummy");
+
+    // mimeType がマップ外で、ファイル名末尾が安全でないケース
+    const result = await uploadImage(
+      buffer,
+      "application/octet-stream",
+      "evil.../bin/sh",
+    );
+
+    expect(result.url).toMatch(/\.jpg$/);
   });
 });
 
@@ -119,25 +147,25 @@ describe("uploadImage (supabase driver)", () => {
   });
 });
 
-// 後始末: ローカルテスト用に作られたファイルが残っても次回テストには影響しないが、
-// 大量に蓄積しないように tests 内で参照しないことを確認。
-describe("local driver の副作用", () => {
-  it("public/uploads/ 配下に書き出す", async () => {
-    process.env.STORAGE_DRIVER = "local";
+describe("uploadImage (driver 解決)", () => {
+  it("STORAGE_DRIVER に 'local'/'supabase' 以外を指定すると例外を投げる", async () => {
+    process.env.STORAGE_DRIVER = "s3";
 
     const { uploadImage } = await import("@/lib/storage");
-    const buffer = Buffer.from("hello");
+    const buffer = Buffer.from("dummy");
+
+    await expect(uploadImage(buffer, "image/jpeg", "x.jpg")).rejects.toThrow(
+      /Invalid STORAGE_DRIVER/,
+    );
+  });
+
+  it("STORAGE_DRIVER 未設定のときはローカルに落ちる", async () => {
+    delete process.env.STORAGE_DRIVER;
+
+    const { uploadImage } = await import("@/lib/storage");
+    const buffer = Buffer.from("dummy");
 
     const result = await uploadImage(buffer, "image/jpeg", "x.jpg");
     expect(result.url.startsWith("/uploads/")).toBe(true);
   });
 });
-
-// helper: テストの後始末で生成された /public/uploads/*.jpg が増えないように
-// uploadImage を呼ぶ際は random filename になる前提だが、テストで作ったファイルを
-// 全削除すると並列実行時に他テストを壊す可能性があるため放置（CI ではクリーンビルド）。
-void writeFile;
-void mkdir;
-void unlink;
-void join;
-void tmpdir;

--- a/tests/unit/services/upload-url.test.ts
+++ b/tests/unit/services/upload-url.test.ts
@@ -1,0 +1,163 @@
+// ---------------------------------------------------------------------------
+// lib/storage.ts: createSignedUploadUrl / convertHeicToJpeg の振る舞いを検証する。
+// - createSignedUploadUrl: Supabase の createSignedUploadUrl を呼び、{signedUrl, path, publicUrl}
+//   の3点セットを返すこと
+// - convertHeicToJpeg: heic-convert を呼んで JPEG Buffer を返すこと
+//
+// 注: heic-convert と @supabase/supabase-js は外部依存のためモック許可。
+// ---------------------------------------------------------------------------
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("heic-convert", () => ({
+  default: vi.fn(),
+}));
+
+import { createClient } from "@supabase/supabase-js";
+import heicConvert from "heic-convert";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("createSignedUploadUrl", () => {
+  function setEnv() {
+    process.env.STORAGE_DRIVER = "supabase";
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+    process.env.SUPABASE_STORAGE_BUCKET = "ootd-images";
+  }
+
+  it("Supabase の createSignedUploadUrl を呼んで {signedUrl, path, publicUrl} を返す", async () => {
+    setEnv();
+
+    const createSignedUploadUrl = vi.fn().mockResolvedValue({
+      data: {
+        signedUrl:
+          "https://example.supabase.co/storage/v1/object/upload/sign/ootd-images/abc.jpg?token=xxx",
+        path: "abc.jpg",
+        token: "xxx",
+      },
+      error: null,
+    });
+    const getPublicUrl = vi.fn().mockReturnValue({
+      data: {
+        publicUrl:
+          "https://example.supabase.co/storage/v1/object/public/ootd-images/abc.jpg",
+      },
+    });
+    const from = vi.fn().mockReturnValue({ createSignedUploadUrl, getPublicUrl });
+    vi.mocked(createClient).mockReturnValue({ storage: { from } } as never);
+
+    const { createSignedUploadUrl: createSignedUploadUrlFn } = await import(
+      "@/lib/storage"
+    );
+
+    const result = await createSignedUploadUrlFn("image/jpeg", "abc.jpg");
+
+    expect(from).toHaveBeenCalledWith("ootd-images");
+    expect(createSignedUploadUrl).toHaveBeenCalled();
+    expect(result.signedUrl).toContain("token=");
+    expect(result.path).toMatch(/\.jpg$/);
+    expect(result.publicUrl).toBe(
+      "https://example.supabase.co/storage/v1/object/public/ootd-images/abc.jpg",
+    );
+  });
+
+  it("拡張子は mimeType から決定する（fallback name に依存しない）", async () => {
+    setEnv();
+
+    const createSignedUploadUrlMock = vi.fn().mockResolvedValue({
+      data: {
+        signedUrl: "https://x/sign?token=t",
+        path: "ignored",
+        token: "t",
+      },
+      error: null,
+    });
+    const getPublicUrl = vi.fn().mockReturnValue({
+      data: { publicUrl: "https://public/url.png" },
+    });
+    const from = vi
+      .fn()
+      .mockReturnValue({ createSignedUploadUrl: createSignedUploadUrlMock, getPublicUrl });
+    vi.mocked(createClient).mockReturnValue({ storage: { from } } as never);
+
+    const { createSignedUploadUrl: createSignedUploadUrlFn } = await import(
+      "@/lib/storage"
+    );
+
+    const result = await createSignedUploadUrlFn("image/png", "noext");
+
+    expect(result.path).toMatch(/\.png$/);
+  });
+
+  it("Supabase が error を返したら例外を投げる", async () => {
+    setEnv();
+
+    const createSignedUploadUrlMock = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: "boom" },
+    });
+    const from = vi.fn().mockReturnValue({
+      createSignedUploadUrl: createSignedUploadUrlMock,
+      getPublicUrl: vi.fn(),
+    });
+    vi.mocked(createClient).mockReturnValue({ storage: { from } } as never);
+
+    const { createSignedUploadUrl: createSignedUploadUrlFn } = await import(
+      "@/lib/storage"
+    );
+
+    await expect(
+      createSignedUploadUrlFn("image/jpeg", "abc.jpg"),
+    ).rejects.toThrow();
+  });
+
+  it("STORAGE_DRIVER が supabase でないと例外を投げる", async () => {
+    process.env.STORAGE_DRIVER = "local";
+
+    const { createSignedUploadUrl: createSignedUploadUrlFn } = await import(
+      "@/lib/storage"
+    );
+
+    await expect(
+      createSignedUploadUrlFn("image/jpeg", "abc.jpg"),
+    ).rejects.toThrow();
+  });
+});
+
+describe("convertHeicToJpeg", () => {
+  it("heic-convert を JPEG フォーマットで呼び出して Buffer を返す", async () => {
+    const out = new ArrayBuffer(8);
+    vi.mocked(heicConvert).mockResolvedValue(out as never);
+
+    const { convertHeicToJpeg } = await import("@/lib/storage");
+    const input = Buffer.from("heic-bytes");
+
+    const result = await convertHeicToJpeg(input);
+
+    expect(heicConvert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: "JPEG",
+        buffer: input,
+      }),
+    );
+    expect(Buffer.isBuffer(result)).toBe(true);
+  });
+
+  it("変換中の例外を呼び出し元に伝播する", async () => {
+    vi.mocked(heicConvert).mockRejectedValue(new Error("decode fail"));
+
+    const { convertHeicToJpeg } = await import("@/lib/storage");
+    const input = Buffer.from("broken");
+
+    await expect(convertHeicToJpeg(input)).rejects.toThrow("decode fail");
+  });
+});

--- a/types/heic-convert.d.ts
+++ b/types/heic-convert.d.ts
@@ -1,0 +1,12 @@
+// heic-convert は型定義を持たないため、最低限必要な形で宣言する。
+// pure JS 実装で Node 上の Buffer も ArrayBuffer も受けるが、
+// このプロジェクトでは Buffer 入力 / JPEG 出力のみで使う。
+declare module "heic-convert" {
+  interface HeicConvertInput {
+    buffer: Buffer | ArrayBufferLike;
+    format: "JPEG" | "PNG";
+    quality?: number;
+  }
+  function heicConvert(input: HeicConvertInput): Promise<ArrayBuffer>;
+  export default heicConvert;
+}

--- a/types/upload.ts
+++ b/types/upload.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+/**
+ * クライアント直接アップロード（署名URL方式）で許可する MIME タイプ。
+ * HEIC/HEIF はブラウザ表示互換性のためサーバーサイド変換経路（/api/upload）に回すので除外。
+ */
+export const DIRECT_UPLOAD_MIME_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+] as const;
+export type DirectUploadMimeType = (typeof DIRECT_UPLOAD_MIME_TYPES)[number];
+
+/**
+ * サーバーサイドで JPEG 変換してから保存する MIME タイプ（iPhone 由来）。
+ */
+export const HEIC_MIME_TYPES = ["image/heic", "image/heif"] as const;
+export type HeicMimeType = (typeof HEIC_MIME_TYPES)[number];
+
+/**
+ * /api/upload-url リクエスト。
+ */
+export const SignedUploadUrlRequestSchema = z.object({
+  mimeType: z.enum(DIRECT_UPLOAD_MIME_TYPES),
+  originalName: z.string().min(1).max(255),
+});
+export type SignedUploadUrlRequest = z.infer<typeof SignedUploadUrlRequestSchema>;
+
+/**
+ * /api/upload-url レスポンス（成功時）。
+ *  - signedUrl: ブラウザから直接 PUT する署名付きURL（短期有効）
+ *  - path: バケット内のオブジェクトパス
+ *  - publicUrl: アップロード後にアプリ側で参照する公開URL
+ */
+export const SignedUploadUrlResponseSchema = z.object({
+  signedUrl: z.string().min(1),
+  path: z.string().min(1),
+  publicUrl: z.string().min(1),
+});
+export type SignedUploadUrlResponse = z.infer<typeof SignedUploadUrlResponseSchema>;


### PR DESCRIPTION
## Summary
- SP では `<input>` に `capture=\"environment\"` を付与してカメラ直起動。PC は通常のファイル選択
- `lib/storage.ts` に画像ストレージドライバを新設。`STORAGE_DRIVER=local|supabase` で切替（既定: `local`）。Supabase Storage を本番用に追加
- ボトムナビのアイコンを内容に合わせて修正: `ClockIcon`→`SearchIcon`（着こなし検索）、`UserIcon`→`CalendarIcon`（OOTD一覧）

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- --run`（83 passed）
- [x] `npm run build`
- [ ] SP（実機 or DevTools エミュレーション）で `/ootd/new` のアップローダタップ → カメラ起動を確認
- [ ] PC で `/ootd/new` のアップローダタップ → 通常のファイル選択を確認
- [ ] `STORAGE_DRIVER=supabase` + Supabase バケット設定で本番アップロード成功を確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * モバイルデバイスでのファイルアップロード時にカメラキャプチャモードを有効化

* **改善**
  * 画像ストレージバックエンドとしてSupabaseに対応
  * ボトムナビゲーションのアイコンとラベルを更新（検索機能と一覧表示）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #26
