### PR TITLE
Fix prod analyze/sticker 400 + restore SP upload chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 ## リリースノート
 
+### v0.9.1 — 2026-05-04
+
+**🔴 hotfix: 本番 OOTD 登録の analyze/sticker 400 + SP アップローダ 2 択シート復元**
+
+- `/api/ootd/analyze` と `/api/ootd/sticker` が `imageUrl.startsWith("/uploads/")` のローカル前提のままで、本番（Supabase Storage publicUrl）で 400 を返していたリグレッションを修正
+- 新規 `lib/image-loader.ts` でローカル `/uploads/` と Supabase publicUrl の両分岐を共通化
+  - SSRF 対策: ホスト名は `SUPABASE_URL` のホストと完全一致のみ許可
+  - リモートは `fetch` で取得、Content-Type から MIME 推定（無ければ拡張子から）
+- `/api/ootd/sticker` の出力も `uploadImage`（driver 抽象）経由に変更。本番では Supabase Storage に書き出す
+- SP の `+` ボタン押下時のカメラ直起動仕様を撤回し、「カメラを起動 / 写真ライブラリから選ぶ / キャンセル」の 2 択シートに戻す（PC は従来通り単一のファイル選択ダイアログ）
+
+---
+
 ### v0.9.0 — 2026-04-29
 
 **SP カメラ起動 + 本番画像ストレージ（Supabase Storage）+ HEIC 対応 + ボトムナビ刷新**

--- a/app/(public)/ootd/new/OotdNewPageClient.tsx
+++ b/app/(public)/ootd/new/OotdNewPageClient.tsx
@@ -15,8 +15,10 @@ type Step = "upload" | "analysis" | "register";
 
 export function OotdNewPageClient() {
   const router = useRouter();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const galleryInputRef = useRef<HTMLInputElement>(null);
   const isMobile = useIsMobile();
+  const [isChooserOpen, setIsChooserOpen] = useState(false);
 
   const [step, setStep] = useState<Step>("upload");
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -223,7 +225,13 @@ export function OotdNewPageClient() {
         <div className="space-y-6">
           <div
             className="flex cursor-pointer flex-col items-center justify-center gap-4 rounded-sm border-2 border-dashed border-denim/20 dark:border-offwhite/20 bg-offwhite-subtle dark:bg-canvas-subtle px-6 py-16 transition-colors hover:border-denim/40 dark:hover:border-offwhite/40"
-            onClick={() => fileInputRef.current?.click()}
+            onClick={() => {
+              if (isMobile) {
+                setIsChooserOpen(true);
+              } else {
+                galleryInputRef.current?.click();
+              }
+            }}
             role="button"
             aria-label="画像を選択"
           >
@@ -253,14 +261,28 @@ export function OotdNewPageClient() {
             )}
           </div>
 
+          {/*
+           * SP では「カメラ」「写真ライブラリ」の 2 択をシートで選ばせ、
+           * それぞれ別の input を click() でトリガーする（capture の有無を切り替えるため）。
+           * PC ではアップロード領域クリックで galleryInput を直接トリガーする。
+           */}
           <input
-            ref={fileInputRef}
+            ref={cameraInputRef}
             type="file"
             accept="image/*"
-            {...(isMobile ? { capture: "environment" as const } : {})}
+            capture="environment"
             className="sr-only"
             onChange={handleFileChange}
-            aria-label="コーデ画像"
+            aria-label="コーデ画像（カメラ）"
+            tabIndex={-1}
+          />
+          <input
+            ref={galleryInputRef}
+            type="file"
+            accept="image/*"
+            className="sr-only"
+            onChange={handleFileChange}
+            aria-label="コーデ画像（写真ライブラリ）"
             tabIndex={-1}
           />
 
@@ -292,6 +314,50 @@ export function OotdNewPageClient() {
           onSubmit={handleRegisterSubmit}
           isSubmitting={isSubmitting}
         />
+      )}
+
+      {isChooserOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="画像入力方法を選択"
+          className="fixed inset-0 z-40 flex items-end justify-center bg-canvas/40 backdrop-blur-sm dark:bg-canvas/60"
+          onClick={() => setIsChooserOpen(false)}
+        >
+          <div
+            className="w-full max-w-md space-y-2 rounded-t-2xl bg-offwhite px-4 pb-8 pt-4 shadow-2xl dark:bg-canvas-subtle"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-denim/20 dark:bg-offwhite/20" />
+            <button
+              type="button"
+              onClick={() => {
+                setIsChooserOpen(false);
+                cameraInputRef.current?.click();
+              }}
+              className="w-full rounded-sm border border-denim/15 bg-offwhite px-4 py-3 text-sm font-medium tracking-wider text-denim hover:border-denim/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:border-offwhite/15 dark:bg-canvas-subtle dark:text-offwhite"
+            >
+              カメラを起動
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setIsChooserOpen(false);
+                galleryInputRef.current?.click();
+              }}
+              className="w-full rounded-sm border border-denim/15 bg-offwhite px-4 py-3 text-sm font-medium tracking-wider text-denim hover:border-denim/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:border-offwhite/15 dark:bg-canvas-subtle dark:text-offwhite"
+            >
+              写真ライブラリから選ぶ
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsChooserOpen(false)}
+              className="w-full rounded-sm border border-transparent px-4 py-3 text-sm tracking-wider text-denim/60 hover:text-denim transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:text-offwhite/60 dark:hover:text-offwhite"
+            >
+              キャンセル
+            </button>
+          </div>
+        </div>
       )}
 
       <OotdAnalysisModal

--- a/app/api/ootd/analyze/route.ts
+++ b/app/api/ootd/analyze/route.ts
@@ -1,20 +1,11 @@
 import { NextResponse } from "next/server";
-import { readFile } from "fs/promises";
-import { join, extname } from "path";
 import { z } from "zod";
 import { analyzeOutfit } from "@/services/ai-analysis";
+import { loadImageBuffer } from "@/lib/image-loader";
 
 const BodySchema = z.object({
   imageUrl: z.string().min(1),
 });
-
-const MIME_MAP: Record<string, "image/jpeg" | "image/png" | "image/gif" | "image/webp"> = {
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".png": "image/png",
-  ".gif": "image/gif",
-  ".webp": "image/webp",
-};
 
 export async function POST(request: Request) {
   const body = (await request.json()) as unknown;
@@ -22,34 +13,26 @@ export async function POST(request: Request) {
 
   if (!parsed.success) {
     return NextResponse.json(
-      { data: null, error: { message: "Invalid input", code: "VALIDATION_ERROR" } },
-      { status: 400 },
-    );
-  }
-
-  const { imageUrl } = parsed.data;
-
-  if (!imageUrl.startsWith("/uploads/")) {
-    return NextResponse.json(
-      { data: null, error: { message: "Invalid image URL", code: "VALIDATION_ERROR" } },
+      {
+        data: null,
+        error: { message: "Invalid input", code: "VALIDATION_ERROR" },
+      },
       { status: 400 },
     );
   }
 
   try {
-    const filePath = join(process.cwd(), "public", imageUrl);
-    const buffer = await readFile(filePath);
+    const { buffer, mimeType } = await loadImageBuffer(parsed.data.imageUrl);
     const base64 = buffer.toString("base64");
-
-    const ext = extname(imageUrl).toLowerCase();
-    const mimeType = MIME_MAP[ext] ?? "image/jpeg";
-
     const result = await analyzeOutfit(base64, mimeType);
     return NextResponse.json({ data: result, error: null }, { status: 200 });
   } catch (error) {
     console.error("[analyze]", error);
     return NextResponse.json(
-      { data: null, error: { message: "Internal server error", code: "INTERNAL_ERROR" } },
+      {
+        data: null,
+        error: { message: "Internal server error", code: "INTERNAL_ERROR" },
+      },
       { status: 500 },
     );
   }

--- a/app/api/ootd/sticker/route.ts
+++ b/app/api/ootd/sticker/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from "next/server";
-import { readFile, mkdir } from "fs/promises";
-import { join, extname } from "path";
-import { randomUUID } from "crypto";
 import sharp from "sharp";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { z } from "zod";
+import { loadImageBuffer } from "@/lib/image-loader";
+import { uploadImage } from "@/lib/storage";
 
 const BodySchema = z.object({
   imageUrl: z.string().min(1),
@@ -23,17 +22,6 @@ Format: {"x": 0.1, "y": 0.05, "width": 0.8, "height": 0.9}
 Where x, y are the top-left corner (0=left/top, 1=right/bottom), width and height are fractions of the image.
 Return ONLY the JSON object, no markdown, no explanation.`;
 
-const MIME_MAP: Record<
-  string,
-  "image/jpeg" | "image/png" | "image/gif" | "image/webp"
-> = {
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".png": "image/png",
-  ".gif": "image/gif",
-  ".webp": "image/webp",
-};
-
 export async function POST(request: Request) {
   const body = (await request.json()) as unknown;
   const parsed = BodySchema.safeParse(body);
@@ -48,33 +36,20 @@ export async function POST(request: Request) {
     );
   }
 
-  const { imageUrl } = parsed.data;
-
-  if (!imageUrl.startsWith("/uploads/")) {
-    return NextResponse.json(
-      {
-        data: null,
-        error: { message: "Invalid image URL", code: "VALIDATION_ERROR" },
-      },
-      { status: 400 },
-    );
-  }
-
   try {
-    const filePath = join(process.cwd(), "public", imageUrl);
-    const buffer = await readFile(filePath);
+    const { buffer, mimeType } = await loadImageBuffer(parsed.data.imageUrl);
 
     const metadata = await sharp(buffer).metadata();
     const imgWidth = metadata.width ?? 512;
     const imgHeight = metadata.height ?? 512;
 
-    const ext = extname(imageUrl).toLowerCase();
-    const mimeType = MIME_MAP[ext] ?? "image/jpeg";
     const base64 = buffer.toString("base64");
 
     // Gemini でバウンディングボックス取得
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY ?? "");
-    const model = genAI.getGenerativeModel({ model: "gemini-3-flash-preview" });
+    const model = genAI.getGenerativeModel({
+      model: "gemini-3-flash-preview",
+    });
 
     const result = await model.generateContent([
       { inlineData: { data: base64, mimeType } },
@@ -109,18 +84,17 @@ export async function POST(request: Request) {
     const width = Math.round(cropW * imgWidth);
     const height = Math.round(cropH * imgHeight);
 
-    const stickersDir = join(process.cwd(), "public", "uploads", "stickers");
-    await mkdir(stickersDir, { recursive: true });
-
-    const filename = `${randomUUID()}.webp`;
-    const outputPath = join(stickersDir, filename);
-
-    await sharp(buffer)
+    const cropped = await sharp(buffer)
       .extract({ left, top, width, height })
       .webp({ quality: 90 })
-      .toFile(outputPath);
+      .toBuffer();
 
-    const stickerUrl = `/uploads/stickers/${filename}`;
+    // 出力もストレージドライバ経由（本番は Supabase Storage）。
+    const { url: stickerUrl } = await uploadImage(
+      cropped,
+      "image/webp",
+      "sticker.webp",
+    );
     return NextResponse.json(
       { data: { stickerUrl }, error: null },
       { status: 200 },

--- a/lib/image-loader.ts
+++ b/lib/image-loader.ts
@@ -1,0 +1,110 @@
+import { readFile } from "fs/promises";
+import { join, extname } from "path";
+
+type SupportedMime = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+
+export interface LoadedImage {
+  buffer: Buffer;
+  mimeType: SupportedMime;
+}
+
+const EXT_TO_MIME: Record<string, SupportedMime> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+const SUPPORTED_MIMES: ReadonlySet<SupportedMime> = new Set<SupportedMime>([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+function resolveMimeFromExtension(pathname: string): SupportedMime {
+  const ext = extname(pathname).toLowerCase();
+  return EXT_TO_MIME[ext] ?? "image/jpeg";
+}
+
+function resolveMimeFromContentType(
+  contentType: string | null,
+  pathname: string,
+): SupportedMime {
+  if (contentType) {
+    const normalized = contentType.split(";")[0]?.trim().toLowerCase();
+    if (normalized && SUPPORTED_MIMES.has(normalized as SupportedMime)) {
+      return normalized as SupportedMime;
+    }
+  }
+  return resolveMimeFromExtension(pathname);
+}
+
+async function loadLocal(imageUrl: string): Promise<LoadedImage> {
+  // imageUrl は "/uploads/<filename>" 形式。public/ 配下から読む。
+  const filePath = join(process.cwd(), "public", imageUrl);
+  const buffer = await readFile(filePath);
+  return { buffer, mimeType: resolveMimeFromExtension(imageUrl) };
+}
+
+async function loadRemote(url: URL): Promise<LoadedImage> {
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    throw new Error(`Failed to fetch image: ${res.status} ${res.statusText}`);
+  }
+  const arrayBuffer = await res.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const mimeType = resolveMimeFromContentType(
+    res.headers.get("content-type"),
+    url.pathname,
+  );
+  return { buffer, mimeType };
+}
+
+function getAllowedRemoteHost(): string | null {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  if (!supabaseUrl) return null;
+  try {
+    return new URL(supabaseUrl).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * imageUrl を Buffer + MIME に解決する。
+ *
+ * 受け付ける URL:
+ * - `/uploads/<file>`: ローカル開発用。public/uploads/ から読む
+ * - `https://<SUPABASE_URL のホスト>/...`: Supabase Storage から fetch
+ *
+ * SSRF 対策:
+ * - ホスト名は SUPABASE_URL のホストと完全一致のみ許可
+ * - file://, ftp:// 等のスキームは拒否
+ */
+export async function loadImageBuffer(imageUrl: string): Promise<LoadedImage> {
+  if (imageUrl.startsWith("/uploads/")) {
+    return loadLocal(imageUrl);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(imageUrl);
+  } catch {
+    throw new Error("Invalid image URL");
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(`Unsupported URL scheme: ${parsed.protocol}`);
+  }
+
+  const allowedHost = getAllowedRemoteHost();
+  if (!allowedHost || parsed.host !== allowedHost) {
+    throw new Error(
+      `URL host "${parsed.host}" is not allowed (expected: "${allowedHost ?? "<none>"}")`,
+    );
+  }
+
+  return loadRemote(parsed);
+}

--- a/tests/unit/components/OotdNewPageClient.test.tsx
+++ b/tests/unit/components/OotdNewPageClient.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 // useRouter / Server Action / useIsMobile を差し替えてレンダリング可能にする。
 vi.mock("next/navigation", () => ({
@@ -16,26 +16,104 @@ vi.mock("@/hooks/useIsMobile", () => ({
 
 import { OotdNewPageClient } from "@/app/(public)/ootd/new/OotdNewPageClient";
 
-function getFileInput(): HTMLInputElement {
-  const input = screen.getByLabelText("コーデ画像", { selector: "input" });
-  expect(input.tagName).toBe("INPUT");
-  return input as HTMLInputElement;
+function getCameraInput(): HTMLInputElement {
+  return screen.getByLabelText("コーデ画像（カメラ）", {
+    selector: "input",
+  }) as HTMLInputElement;
 }
 
-describe("OotdNewPageClient — capture 属性", () => {
+function getGalleryInput(): HTMLInputElement {
+  return screen.getByLabelText("コーデ画像（写真ライブラリ）", {
+    selector: "input",
+  }) as HTMLInputElement;
+}
+
+describe("OotdNewPageClient — アップロード入力の構成", () => {
   beforeEach(() => {
     useIsMobileMock.mockReset();
   });
 
-  it("SP（isMobile=true）のとき file input に capture='environment' が付く", () => {
+  it("カメラ用 input は常に capture='environment' を持つ（モバイル時のみ click される）", () => {
     useIsMobileMock.mockReturnValue(true);
     render(<OotdNewPageClient />);
-    expect(getFileInput().getAttribute("capture")).toBe("environment");
+    expect(getCameraInput().getAttribute("capture")).toBe("environment");
   });
 
-  it("PC（isMobile=false）のとき file input に capture 属性が付かない", () => {
+  it("ライブラリ用 input は capture 属性を持たない", () => {
+    useIsMobileMock.mockReturnValue(true);
+    render(<OotdNewPageClient />);
+    expect(getGalleryInput().hasAttribute("capture")).toBe(false);
+  });
+
+  it("PC でもカメラ用とライブラリ用の input が両方存在する（aria-label で区別可能）", () => {
     useIsMobileMock.mockReturnValue(false);
     render(<OotdNewPageClient />);
-    expect(getFileInput().hasAttribute("capture")).toBe(false);
+    expect(getCameraInput()).toBeInTheDocument();
+    expect(getGalleryInput()).toBeInTheDocument();
+  });
+});
+
+describe("OotdNewPageClient — SP 2 択シート", () => {
+  beforeEach(() => {
+    useIsMobileMock.mockReset();
+  });
+
+  it("SP でアップロード領域をタップすると 2 択シートが開く", () => {
+    useIsMobileMock.mockReturnValue(true);
+    render(<OotdNewPageClient />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /画像を選択/ }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /カメラを起動/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /写真ライブラリから選ぶ/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("PC でアップロード領域をタップしてもシートは出ない（直接ファイル選択ダイアログ）", () => {
+    useIsMobileMock.mockReturnValue(false);
+    render(<OotdNewPageClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: /画像を選択/ }));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("シートで「カメラを起動」をタップするとシートが閉じる", () => {
+    useIsMobileMock.mockReturnValue(true);
+    render(<OotdNewPageClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: /画像を選択/ }));
+    fireEvent.click(screen.getByRole("button", { name: /カメラを起動/ }));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("シートで「写真ライブラリから選ぶ」をタップするとシートが閉じる", () => {
+    useIsMobileMock.mockReturnValue(true);
+    render(<OotdNewPageClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: /画像を選択/ }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /写真ライブラリから選ぶ/ }),
+    );
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("シートに「キャンセル」ボタンがあり、押すと閉じる", () => {
+    useIsMobileMock.mockReturnValue(true);
+    render(<OotdNewPageClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: /画像を選択/ }));
+    fireEvent.click(screen.getByRole("button", { name: /キャンセル/ }));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 });

--- a/tests/unit/components/OotdNewPageClient.upload.test.tsx
+++ b/tests/unit/components/OotdNewPageClient.upload.test.tsx
@@ -21,7 +21,12 @@ vi.mock("@/hooks/useIsMobile", () => ({
 import { OotdNewPageClient } from "@/app/(public)/ootd/new/OotdNewPageClient";
 
 function getFileInput(): HTMLInputElement {
-  const input = screen.getByLabelText("コーデ画像", { selector: "input" });
+  // SP の 2 択シート導入後、ファイル選択用 input は「カメラ」と「写真ライブラリ」の
+  // 2 つに分かれた。アップロード経路の検証はどちらの input でも同じ handleFileChange を
+  // 経由するため、ライブラリ用 input をターゲットに onChange を発火する。
+  const input = screen.getByLabelText("コーデ画像（写真ライブラリ）", {
+    selector: "input",
+  });
   return input as HTMLInputElement;
 }
 

--- a/tests/unit/services/image-loader.test.ts
+++ b/tests/unit/services/image-loader.test.ts
@@ -1,0 +1,156 @@
+// ---------------------------------------------------------------------------
+// lib/image-loader の振る舞いを検証する。
+// - /uploads/<file>: ローカル開発用の public/uploads/ から読む
+// - https://<SUPABASE_URL のホスト>/...: fetch で取得
+// - 上記以外（外部任意 URL）: SSRF 防止のため拒否
+// - 不正 URL: 拒否
+//
+// 注: fs/promises と global.fetch をモック化する（外部 I/O のためモック許可）。
+// ---------------------------------------------------------------------------
+
+vi.mock("fs/promises", () => {
+  const readFile = vi.fn();
+  return { default: { readFile }, readFile };
+});
+
+import { readFile } from "fs/promises";
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_FETCH = global.fetch;
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe("loadImageBuffer (local)", () => {
+  it("/uploads/<file> はローカルファイルから読み、拡張子から MIME を決める", async () => {
+    vi.mocked(readFile).mockResolvedValue(Buffer.from("local-bytes"));
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+    const result = await loadImageBuffer("/uploads/abc.png");
+
+    expect(readFile).toHaveBeenCalled();
+    expect(result.buffer.toString()).toBe("local-bytes");
+    expect(result.mimeType).toBe("image/png");
+  });
+
+  it("/uploads/<file>.jpg は image/jpeg と解決する", async () => {
+    vi.mocked(readFile).mockResolvedValue(Buffer.from("x"));
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+    const result = await loadImageBuffer("/uploads/x.jpg");
+
+    expect(result.mimeType).toBe("image/jpeg");
+  });
+});
+
+describe("loadImageBuffer (Supabase remote)", () => {
+  it("SUPABASE_URL ホストの URL は fetch で取得し、Content-Type から MIME を決める", async () => {
+    process.env.SUPABASE_URL = "https://abc.supabase.co";
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer, {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+    global.fetch = fetchMock as never;
+
+    const url =
+      "https://abc.supabase.co/storage/v1/object/public/ootd-images/abc.png";
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+    const result = await loadImageBuffer(url);
+
+    expect(fetchMock).toHaveBeenCalledWith(url);
+    expect(result.mimeType).toBe("image/png");
+    expect(result.buffer.length).toBe(4);
+  });
+
+  it("Content-Type が無いときは拡張子から MIME を補完する", async () => {
+    process.env.SUPABASE_URL = "https://abc.supabase.co";
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([0]).buffer, {
+        status: 200,
+        headers: {},
+      }),
+    );
+    global.fetch = fetchMock as never;
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+    const result = await loadImageBuffer(
+      "https://abc.supabase.co/storage/v1/object/public/ootd-images/x.webp",
+    );
+
+    expect(result.mimeType).toBe("image/webp");
+  });
+
+  it("fetch が 200 以外を返したら例外を投げる", async () => {
+    process.env.SUPABASE_URL = "https://abc.supabase.co";
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 }));
+    global.fetch = fetchMock as never;
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+
+    await expect(
+      loadImageBuffer(
+        "https://abc.supabase.co/storage/v1/object/public/ootd-images/x.jpg",
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+describe("loadImageBuffer (バリデーション)", () => {
+  it("SUPABASE_URL のホストと一致しない外部 URL は拒否する（SSRF 防止）", async () => {
+    process.env.SUPABASE_URL = "https://abc.supabase.co";
+
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as never;
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+
+    await expect(
+      loadImageBuffer("https://evil.example.com/x.jpg"),
+    ).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("/uploads/ でも https:// でもない URL は拒否する", async () => {
+    process.env.SUPABASE_URL = "https://abc.supabase.co";
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+
+    await expect(loadImageBuffer("file:///etc/passwd")).rejects.toThrow();
+    await expect(
+      loadImageBuffer("ftp://abc.supabase.co/x.jpg"),
+    ).rejects.toThrow();
+    await expect(loadImageBuffer("not-a-url")).rejects.toThrow();
+  });
+
+  it("SUPABASE_URL 未設定でもローカル URL は読める", async () => {
+    delete process.env.SUPABASE_URL;
+    vi.mocked(readFile).mockResolvedValue(Buffer.from("ok"));
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+    const result = await loadImageBuffer("/uploads/x.jpg");
+
+    expect(result.buffer.toString()).toBe("ok");
+  });
+
+  it("SUPABASE_URL 未設定で https URL は拒否される", async () => {
+    delete process.env.SUPABASE_URL;
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+
+    await expect(
+      loadImageBuffer("https://abc.supabase.co/x.jpg"),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- **🔴 Hotfix**: `/api/ootd/analyze` と `/api/ootd/sticker` が \`/uploads/\` ローカル前提のままだったため、PR #25 で本番が 400 を返す状態（OOTD 登録フローが死亡）を修正
- 共通の画像ローダ \`lib/image-loader.ts\` を新設し、\`/uploads/\` とSupabase publicUrl の両方を扱う。SSRF 対策で \`SUPABASE_URL\` のホスト名のみ allowlist
- sticker 出力も \`uploadImage\` (driver 抽象) 経由に変更し、本番でも動作するように
- SP の \`+\` ボタンタップ時のカメラ直起動を撤回し、**「カメラを起動 / 写真ライブラリから選ぶ / キャンセル」** の 2 択シートに戻す

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test -- --run\`（13 ファイル / 124 件）
- [x] \`npm run build\`
- [ ] 本番デプロイ後、Supabase URL の画像で \`/api/ootd/analyze\` と sticker 生成が 200 を返すこと
- [ ] SP で \`/ootd/new\` を開きアップロード領域タップ → 2 択シートが表示されること
- [ ] PC で \`/ootd/new\` を開きアップロード領域タップ → 通常のファイル選択ダイアログのみ

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 本番環境での `/api/ootd/analyze` と `/api/ootd/sticker` エンドポイントが 400 エラーになる問題を修正

* **新機能**
  * モバイル版：「+」ボタン押下時に「カメラを起動」「写真ライブラリから選ぶ」「キャンセル」から選べるシートを表示するように改善

* **ドキュメント**
  * v0.9.1 (2026-05-04) のリリースノートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->