### PR TITLE
fix(security): patch path traversal in image-loader

### DIFF
--- a/lib/image-loader.ts
+++ b/lib/image-loader.ts
@@ -1,5 +1,5 @@
 import { readFile } from "fs/promises";
-import { join, extname } from "path";
+import { extname, resolve, sep } from "path";
 
 type SupportedMime = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
 
@@ -42,10 +42,16 @@ function resolveMimeFromContentType(
 }
 
 async function loadLocal(imageUrl: string): Promise<LoadedImage> {
-  // imageUrl は "/uploads/<filename>" 形式。public/ 配下から読む。
-  const filePath = join(process.cwd(), "public", imageUrl);
+  // imageUrl は "/uploads/<relative>" 形式。
+  // パストラバーサル防止: resolve 後のパスが必ず uploads ディレクトリ配下にあることを検証する。
+  const uploadsDir = resolve(process.cwd(), "public", "uploads");
+  const relativePath = imageUrl.slice("/uploads/".length);
+  const filePath = resolve(uploadsDir, relativePath);
+  if (filePath !== uploadsDir && !filePath.startsWith(`${uploadsDir}${sep}`)) {
+    throw new Error("Invalid image URL");
+  }
   const buffer = await readFile(filePath);
-  return { buffer, mimeType: resolveMimeFromExtension(imageUrl) };
+  return { buffer, mimeType: resolveMimeFromExtension(relativePath) };
 }
 
 async function loadRemote(url: URL): Promise<LoadedImage> {

--- a/tests/unit/components/OotdNewPageClient.test.tsx
+++ b/tests/unit/components/OotdNewPageClient.test.tsx
@@ -85,25 +85,35 @@ describe("OotdNewPageClient — SP 2 択シート", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("シートで「カメラを起動」をタップするとシートが閉じる", () => {
+  it("シートで「カメラを起動」をタップするとカメラ用 input.click() が呼ばれ、シートが閉じる", () => {
     useIsMobileMock.mockReturnValue(true);
     render(<OotdNewPageClient />);
+
+    const cameraClickSpy = vi.spyOn(getCameraInput(), "click");
+    const galleryClickSpy = vi.spyOn(getGalleryInput(), "click");
 
     fireEvent.click(screen.getByRole("button", { name: /画像を選択/ }));
     fireEvent.click(screen.getByRole("button", { name: /カメラを起動/ }));
 
+    expect(cameraClickSpy).toHaveBeenCalledTimes(1);
+    expect(galleryClickSpy).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("シートで「写真ライブラリから選ぶ」をタップするとシートが閉じる", () => {
+  it("シートで「写真ライブラリから選ぶ」をタップするとライブラリ用 input.click() が呼ばれ、シートが閉じる", () => {
     useIsMobileMock.mockReturnValue(true);
     render(<OotdNewPageClient />);
+
+    const cameraClickSpy = vi.spyOn(getCameraInput(), "click");
+    const galleryClickSpy = vi.spyOn(getGalleryInput(), "click");
 
     fireEvent.click(screen.getByRole("button", { name: /画像を選択/ }));
     fireEvent.click(
       screen.getByRole("button", { name: /写真ライブラリから選ぶ/ }),
     );
 
+    expect(galleryClickSpy).toHaveBeenCalledTimes(1);
+    expect(cameraClickSpy).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 

--- a/tests/unit/services/image-loader.test.ts
+++ b/tests/unit/services/image-loader.test.ts
@@ -154,3 +154,32 @@ describe("loadImageBuffer (バリデーション)", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("loadImageBuffer (パストラバーサル防止)", () => {
+  it("/uploads/../<外部ファイル> は拒否し、readFile を呼ばない", async () => {
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+
+    await expect(
+      loadImageBuffer("/uploads/../../etc/passwd"),
+    ).rejects.toThrow();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("/uploads/../secret.env のような同階層脱出も拒否する", async () => {
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+
+    await expect(loadImageBuffer("/uploads/../secret.env")).rejects.toThrow();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("/uploads/sub/file.jpg のようなサブディレクトリは引き続き許可する", async () => {
+    vi.mocked(readFile).mockResolvedValue(Buffer.from("ok"));
+
+    const { loadImageBuffer } = await import("@/lib/image-loader");
+    const result = await loadImageBuffer("/uploads/sub/file.jpg");
+
+    expect(readFile).toHaveBeenCalled();
+    expect(result.buffer.toString()).toBe("ok");
+    expect(result.mimeType).toBe("image/jpeg");
+  });
+});


### PR DESCRIPTION
## Summary
- 🔴 **Security fix**: PR #28 の CodeRabbit Critical 指摘に対応。\`/uploads/../../etc/passwd\` のような入力で \`public/uploads\` 配下の外を読める脆弱性を修正
- \`loadLocal\` を \`path.resolve\` で正規化し、解決先が \`uploadsDir\` 配下にあることを検証して逸脱を例外化
- パストラバーサル回帰テスト 3 件追加（外部ファイル拒否 / 同階層脱出拒否 / サブディレクトリは許可）
- SP 2 択シートのテストに \`vi.spyOn\` を追加し、対応する input の \`click()\` が呼ばれることまで検証

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test -- --run\`（13 ファイル / 127 件）
- [ ] \`npm run build\`（ローカルは Google Fonts fetch エラーで CI 待ち）

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ローカル画像ファイルのパストラバーサル攻撃への対策を強化しました。

* **Tests**
  * 画像読み込み機能のセキュリティテストを追加しました。
  * カメラと写真ライブラリの操作テストを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->