### PR TITLE
fix: allow Supabase Storage host in next/image remotePatterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 ## リリースノート
 
+### v0.9.2 — 2026-05-06
+
+**🔴 hotfix: 本番で Supabase Storage 画像が `<Image>` で表示されない問題を修正**
+
+- `next.config.ts` に `images.remotePatterns` を追加し、Supabase Storage の公開 URL を Next.js `<Image>` で許可
+- ホスト名は `process.env.SUPABASE_URL` から派生（ハードコード回避、`lib/storage.ts` と同じ env を参照）
+- pathname を `/storage/v1/object/public/**` に絞り、ホスト全体の不要な開放を避ける
+- `SUPABASE_URL` 未設定時は空配列にフォールバック（ローカル開発で env 無しでも build を壊さない）
+
+---
+
 ### v0.9.1 — 2026-05-04
 
 **🔴 hotfix: 本番 OOTD 登録の analyze/sticker 400 + SP アップローダ 2 択シート復元**

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,29 @@
 import type { NextConfig } from "next";
 
+function resolveSupabaseHost(): string | null {
+  const url = process.env.SUPABASE_URL;
+  if (!url) return null;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
+const supabaseHost = resolveSupabaseHost();
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: supabaseHost
+      ? [
+          {
+            protocol: "https",
+            hostname: supabaseHost,
+            pathname: "/storage/v1/object/public/**",
+          },
+        ]
+      : [],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 変更の概要
本番で Supabase Storage に保存された画像が `<Image>` コンポーネントで表示されない問題を修正する。`next.config.ts` に `images.remotePatterns` を追加し、Supabase Storage の公開 URL を許可する。

## 変更の理由
Next.js の `<Image>` は外部ホストの画像を `images.remotePatterns` で明示的に許可しないと最適化を拒否する。`next.config.ts` がデフォルトのまま空だったため、Supabase Storage の公開 URL（`https://<project-ref>.supabase.co/storage/v1/object/public/...`）が読み込めず、AI 診断モーダル・投稿詳細の両方で画像が壊れたアイコンになっていた。

## 変更内容
- `next.config.ts` に `images.remotePatterns` を追加
- ホスト名はハードコードせず `process.env.SUPABASE_URL` から派生（`lib/storage.ts` と同じ env を参照して整合性を保つ）
- pathname を `/storage/v1/object/public/**` に絞り、不要な開放を避ける
- `SUPABASE_URL` 未設定時は空配列にフォールバック（ローカル開発で env 無しでも build を壊さない）

## テスト方法
ローカルで以下が全件グリーンであることを確認済み:
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --run`（127 件）

本番デプロイ後に以下を目視確認:
- [ ] /ootd/new で画像をアップロードし、AI 診断モーダルにプレビューが表示される
- [ ] 投稿後、/ootd/[id] で画像が表示される

## 影響範囲
- `next.config.ts` のみ。ランタイム挙動は `<Image>` のリモート画像最適化に影響
- `SUPABASE_URL` がビルド時に存在することが前提（Vercel 本番には設定済み）

## チェックリスト
- [x] コードレビューを依頼した
- [x] テストが完了している
- [ ] ドキュメントを更新した（必要に応じて）
- [x] コミットメッセージが適切である

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * Supabase ストレージの本番環境での画像表示を安定化するため、リモート画像設定が動的に調整されるようになりました。
* **修正**
  * 本番での画像表示に関するホットフィックスを適用しました。
* **ドキュメント**
  * v0.9.2 のリリースノートを README に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->