### PR TITLE
fix: prevent analyze errors from image/jpg MIME and non-standard colorCode

### DIFF
--- a/app/api/ootd/analyze/route.ts
+++ b/app/api/ootd/analyze/route.ts
@@ -21,52 +21,52 @@ const ALLOWED_MIME_TYPES = new Set<string>([
  * 出力: { data: OotdAnalysisResult, error: null }
  */
 export async function POST(request: Request) {
-  const formData = await request.formData();
-  const file = formData.get("image");
-
-  if (!file || !(file instanceof File)) {
-    return NextResponse.json(
-      {
-        data: null,
-        error: { message: "No image file provided", code: "MISSING_FILE" },
-      },
-      { status: 400 },
-    );
-  }
-
-  const mimeType = file.type.toLowerCase();
-  if (!ALLOWED_MIME_TYPES.has(mimeType)) {
-    return NextResponse.json(
-      {
-        data: null,
-        error: {
-          message: "Only image files are allowed",
-          code: "INVALID_FILE_TYPE",
-        },
-      },
-      { status: 400 },
-    );
-  }
-
-  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
-    return NextResponse.json(
-      {
-        data: null,
-        error: { message: "File is too large", code: "FILE_TOO_LARGE" },
-      },
-      { status: 413 },
-    );
-  }
-
   try {
+    const formData = await request.formData();
+    const file = formData.get("image");
+
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json(
+        {
+          data: null,
+          error: { message: "No image file provided", code: "MISSING_FILE" },
+        },
+        { status: 400 },
+      );
+    }
+
+    const mimeType = file.type.toLowerCase();
+    if (!ALLOWED_MIME_TYPES.has(mimeType)) {
+      return NextResponse.json(
+        {
+          data: null,
+          error: {
+            message: "Only image files are allowed",
+            code: "INVALID_FILE_TYPE",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+      return NextResponse.json(
+        {
+          data: null,
+          error: { message: "File is too large", code: "FILE_TOO_LARGE" },
+        },
+        { status: 413 },
+      );
+    }
+
     const bytes = await file.arrayBuffer();
     // 入力 Buffer と HEIC 変換後 Buffer は @types/node 上で異なる generic 引数を持つため、
     // 受け側の型を最も広い ArrayBufferLike に揃えて再代入を許容する。
     let buffer: Buffer<ArrayBufferLike> = Buffer.from(bytes);
-    let geminiMime = mimeType;
+    // "image/jpg" は非標準。Gemini API は "image/jpeg" のみ受け付けるため正規化する。
+    let geminiMime = mimeType === "image/jpg" ? "image/jpeg" : mimeType;
 
     if (HEIC_MIME_SET.has(mimeType)) {
-      // Gemini 側で HEIC を直接扱えないケースに備え、JPEG に正規化する。
       buffer = await convertHeicToJpeg(buffer);
       geminiMime = "image/jpeg";
     }

--- a/services/ai-analysis.ts
+++ b/services/ai-analysis.ts
@@ -109,5 +109,40 @@ export async function analyzeOutfit(
     : text;
 
   const parsed = JSON.parse(jsonText) as unknown;
-  return OotdAnalysisResultSchema.parse(parsed);
+  return OotdAnalysisResultSchema.parse(normalizeAnalysisResult(parsed));
+}
+
+function normalizeColorCode(code: string): string {
+  // 3桁 hex: #RGB → #RRGGBB
+  const threeDigit = /^#([0-9A-Fa-f]{3})$/.exec(code);
+  if (threeDigit) {
+    const [r, g, b] = threeDigit[1].split("");
+    return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+  // 8桁 hex（alpha付き）: #RRGGBBAA → #RRGGBB
+  const eightDigit = /^#([0-9A-Fa-f]{6})[0-9A-Fa-f]{2}$/.exec(code);
+  if (eightDigit) {
+    return `#${eightDigit[1]}`.toUpperCase();
+  }
+  // 6桁 hex: 大文字正規化
+  if (/^#[0-9A-Fa-f]{6}$/.test(code)) {
+    return code.toUpperCase();
+  }
+  return code;
+}
+
+function normalizeAnalysisResult(raw: unknown): unknown {
+  if (typeof raw !== "object" || raw === null) return raw;
+  const obj = raw as Record<string, unknown>;
+  if (Array.isArray(obj.colorPalette)) {
+    obj.colorPalette = obj.colorPalette.map((item: unknown) => {
+      if (typeof item !== "object" || item === null) return item;
+      const i = item as Record<string, unknown>;
+      if (typeof i.colorCode === "string") {
+        i.colorCode = normalizeColorCode(i.colorCode);
+      }
+      return i;
+    });
+  }
+  return obj;
 }

--- a/services/ai-analysis.ts
+++ b/services/ai-analysis.ts
@@ -112,7 +112,7 @@ export async function analyzeOutfit(
   return OotdAnalysisResultSchema.parse(normalizeAnalysisResult(parsed));
 }
 
-function normalizeColorCode(code: string): string {
+export function normalizeColorCode(code: string): string {
   // 3桁 hex: #RGB → #RRGGBB
   const threeDigit = /^#([0-9A-Fa-f]{3})$/.exec(code);
   if (threeDigit) {
@@ -131,7 +131,7 @@ function normalizeColorCode(code: string): string {
   return code;
 }
 
-function normalizeAnalysisResult(raw: unknown): unknown {
+export function normalizeAnalysisResult(raw: unknown): unknown {
   if (typeof raw !== "object" || raw === null) return raw;
   const obj = raw as Record<string, unknown>;
   if (Array.isArray(obj.colorPalette)) {

--- a/tests/unit/api/analyze.test.ts
+++ b/tests/unit/api/analyze.test.ts
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------------
+// POST /api/ootd/analyze Route Handler の振る舞いを検証する。
+// - formData() 失敗       -> 500 INTERNAL_ERROR
+// - image フィールドなし  -> 400 MISSING_FILE
+// - 不正 MIME タイプ      -> 400 INVALID_FILE_TYPE
+// - ファイルサイズ超過    -> 413 FILE_TOO_LARGE
+// - 有効 JPEG             -> 200 (analyzeOutfit 呼び出し確認)
+// - image/jpg 正規化      -> analyzeOutfit に "image/jpeg" を渡す
+// - HEIC 変換パス         -> convertHeicToJpeg 後に "image/jpeg" で呼ぶ
+// - analyzeOutfit 失敗    -> 500 INTERNAL_ERROR (内部詳細を漏らさない)
+// ---------------------------------------------------------------------------
+
+const analyzeOutfitMock = vi.fn();
+const convertHeicToJpegMock = vi.fn();
+
+vi.mock("@/services/ai-analysis", () => ({
+  analyzeOutfit: (...args: unknown[]) => analyzeOutfitMock(...args),
+  normalizeColorCode: vi.fn(),
+  normalizeAnalysisResult: vi.fn(),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  convertHeicToJpeg: (...args: unknown[]) => convertHeicToJpegMock(...args),
+}));
+
+import { POST } from "@/app/api/ootd/analyze/route";
+
+const MOCK_RESULT = {
+  oneLiner: "テストコーデ",
+  colorPalette: [{ name: "黒", colorCode: "#000000", percentage: 100 }],
+  styles: [{ name: "ストリート", percentage: 100 }],
+  description: "テスト説明",
+  detectedItems: [{ name: "Tシャツ" }],
+};
+
+function makeReq(formData: FormData): Request {
+  return {
+    formData: vi.fn().mockResolvedValue(formData),
+  } as unknown as Request;
+}
+
+function makeFailingReq(): Request {
+  return {
+    formData: vi.fn().mockRejectedValue(new Error("boundary parse error")),
+  } as unknown as Request;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/ootd/analyze", () => {
+  it("formData() が失敗したら 500 INTERNAL_ERROR を返す", async () => {
+    const res = await POST(makeFailingReq());
+    expect(res.status).toBe(500);
+    const json = (await res.json()) as { error?: { code?: string } };
+    expect(json.error?.code).toBe("INTERNAL_ERROR");
+  });
+
+  it("image フィールドがなければ 400 MISSING_FILE を返す", async () => {
+    const res = await POST(makeReq(new FormData()));
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: { code?: string } };
+    expect(json.error?.code).toBe("MISSING_FILE");
+  });
+
+  it("許可外の MIME タイプは 400 INVALID_FILE_TYPE を返す", async () => {
+    const file = new File(["fake"], "test.svg", { type: "image/svg+xml" });
+    const fd = new FormData();
+    fd.append("image", file);
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: { code?: string } };
+    expect(json.error?.code).toBe("INVALID_FILE_TYPE");
+  });
+
+  it("10MB 超のファイルは 413 FILE_TOO_LARGE を返す", async () => {
+    const file = new File(["fake"], "large.jpg", { type: "image/jpeg" });
+    Object.defineProperty(file, "size", { value: 10 * 1024 * 1024 + 1 });
+    const fd = new FormData();
+    fd.append("image", file);
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(413);
+    const json = (await res.json()) as { error?: { code?: string } };
+    expect(json.error?.code).toBe("FILE_TOO_LARGE");
+  });
+
+  it("有効な JPEG ファイルで 200 と分析結果を返す", async () => {
+    analyzeOutfitMock.mockResolvedValue(MOCK_RESULT);
+    const file = new File([new Uint8Array(10)], "test.jpg", {
+      type: "image/jpeg",
+    });
+    const fd = new FormData();
+    fd.append("image", file);
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data?: typeof MOCK_RESULT; error: null };
+    expect(json.data).toEqual(MOCK_RESULT);
+    expect(json.error).toBeNull();
+    expect(analyzeOutfitMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "image/jpeg",
+    );
+  });
+
+  it("image/jpg は image/jpeg に正規化して analyzeOutfit を呼ぶ", async () => {
+    analyzeOutfitMock.mockResolvedValue(MOCK_RESULT);
+    const file = new File([new Uint8Array(10)], "photo.jpg", {
+      type: "image/jpg",
+    });
+    const fd = new FormData();
+    fd.append("image", file);
+    await POST(makeReq(fd));
+    expect(analyzeOutfitMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "image/jpeg",
+    );
+  });
+
+  it("HEIC ファイルは JPEG 変換後に image/jpeg で analyzeOutfit を呼ぶ", async () => {
+    convertHeicToJpegMock.mockResolvedValue(Buffer.from([0xff, 0xd8, 0xff]));
+    analyzeOutfitMock.mockResolvedValue(MOCK_RESULT);
+    const file = new File([new Uint8Array(10)], "photo.heic", {
+      type: "image/heic",
+    });
+    const fd = new FormData();
+    fd.append("image", file);
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(200);
+    expect(convertHeicToJpegMock).toHaveBeenCalled();
+    expect(analyzeOutfitMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "image/jpeg",
+    );
+  });
+
+  it("analyzeOutfit が失敗したら 500 を返し、内部エラーを露出しない", async () => {
+    analyzeOutfitMock.mockRejectedValue(new Error("gemini-internal-error"));
+    const file = new File([new Uint8Array(10)], "test.jpg", {
+      type: "image/jpeg",
+    });
+    const fd = new FormData();
+    fd.append("image", file);
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(500);
+    const json = (await res.json()) as {
+      error?: { code?: string; message?: string };
+    };
+    expect(json.error?.code).toBe("INTERNAL_ERROR");
+    expect(json.error?.message).not.toContain("gemini-internal-error");
+  });
+});

--- a/tests/unit/services/ai-analysis.test.ts
+++ b/tests/unit/services/ai-analysis.test.ts
@@ -1,0 +1,99 @@
+import {
+  normalizeColorCode,
+  normalizeAnalysisResult,
+} from "@/services/ai-analysis";
+
+describe("normalizeColorCode", () => {
+  it("3桁 hex #1aF を #11AAFF に展開・大文字化する", () => {
+    expect(normalizeColorCode("#1aF")).toBe("#11AAFF");
+  });
+
+  it("3桁 hex #abc を #AABBCC に展開・大文字化する", () => {
+    expect(normalizeColorCode("#abc")).toBe("#AABBCC");
+  });
+
+  it("8桁 hex #11223344 のアルファを除去して #112233 を返す", () => {
+    expect(normalizeColorCode("#11223344")).toBe("#112233");
+  });
+
+  it("6桁 lowercase hex #aabbcc を #AABBCC に大文字化する", () => {
+    expect(normalizeColorCode("#aabbcc")).toBe("#AABBCC");
+  });
+
+  it("有効な 6桁 uppercase hex はそのまま返す", () => {
+    expect(normalizeColorCode("#AABBCC")).toBe("#AABBCC");
+  });
+
+  it("rgb() 形式は変換せずそのまま返す", () => {
+    expect(normalizeColorCode("rgb(1,2,3)")).toBe("rgb(1,2,3)");
+  });
+
+  it("色名 'red' は変換せずそのまま返す", () => {
+    expect(normalizeColorCode("red")).toBe("red");
+  });
+
+  it("空文字はそのまま返す", () => {
+    expect(normalizeColorCode("")).toBe("");
+  });
+});
+
+describe("normalizeAnalysisResult", () => {
+  it("null を渡したらそのまま返す", () => {
+    expect(normalizeAnalysisResult(null)).toBeNull();
+  });
+
+  it("文字列を渡したらそのまま返す", () => {
+    expect(normalizeAnalysisResult("text")).toBe("text");
+  });
+
+  it("colorPalette を持たないオブジェクトはそのまま返す", () => {
+    const input = { oneLiner: "test" };
+    expect(normalizeAnalysisResult(input)).toEqual({ oneLiner: "test" });
+  });
+
+  it("colorPalette 内の 3桁 hex colorCode が #RRGGBB に正規化される", () => {
+    const input = {
+      colorPalette: [{ name: "A", colorCode: "#abc", percentage: 50 }],
+    };
+    const result = normalizeAnalysisResult(input) as {
+      colorPalette: { colorCode: string }[];
+    };
+    expect(result.colorPalette[0].colorCode).toBe("#AABBCC");
+  });
+
+  it("colorPalette 内の 8桁 hex colorCode からアルファが除去される", () => {
+    const input = {
+      colorPalette: [{ name: "B", colorCode: "#11223344", percentage: 50 }],
+    };
+    const result = normalizeAnalysisResult(input) as {
+      colorPalette: { colorCode: string }[];
+    };
+    expect(result.colorPalette[0].colorCode).toBe("#112233");
+  });
+
+  it("colorPalette 内の非オブジェクト要素はそのまま保持される", () => {
+    const input = {
+      colorPalette: [
+        "not-an-object",
+        { name: "A", colorCode: "#abc", percentage: 100 },
+      ],
+    };
+    const result = normalizeAnalysisResult(input) as {
+      colorPalette: unknown[];
+    };
+    expect(result.colorPalette[0]).toBe("not-an-object");
+    expect(
+      (result.colorPalette[1] as { colorCode: string }).colorCode,
+    ).toBe("#AABBCC");
+  });
+
+  it("colorCode が文字列でない要素はスキップして値を保持する", () => {
+    const input = {
+      colorPalette: [{ name: "A", colorCode: 12345, percentage: 100 }],
+    };
+    const result = normalizeAnalysisResult(input) as {
+      colorPalette: { colorCode: unknown }[];
+    };
+    expect(result.colorPalette[0].colorCode).toBe(12345);
+  });
+});


### PR DESCRIPTION
- Wrap entire POST handler in try/catch so formData() errors are caught
- Normalize "image/jpg" → "image/jpeg" before passing mimeType to Gemini
  (Gemini API rejects "image/jpg" with protobuf pattern validation error)
- Add normalizeAnalysisResult() to fix AI response colorCode variants:
  3-digit hex (#RGB→#RRGGBB), 8-digit hex with alpha (#RRGGBBAA→#RRGGBB)

Fixes "The string did not match the expected pattern." shown on analyze.

https://claude.ai/code/session_01NvkkVmzMz3c1o1eQ682YcY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 画像アップロード時のエラーハンドリングを強化し、欠落・不正形式・サイズ超過で適切なエラー応答を返すようになりました
  * HEIC画像をJPEGに変換して正しく処理するよう改善しました
  * 分析結果のカラーパレット表記を正規化し、一貫した色コード表示を提供します

* **テスト**
  * ルート処理と色コード正規化の動作を検証する単体テストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->