### PR TITLE
feat: compress images client-side before AI analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 ## リリースノート
 
+### v0.9.5 — 2026-05-10
+
+**OOTD アップロード時の 413（Request Entity Too Large）エラー修正**
+
+- iPhone HEIC を JPEG 変換した直後の高解像度画像が Vercel serverless function の body size 上限（4.5MB）を超え、`/api/ootd/analyze` のレスポンスを `Unexpected token 'R', "Request En"... is not valid JSON` で破壊していた問題を修正
+- `lib/image-compress.ts` を新規追加。クライアント側で `<canvas>` 経由で max edge 1920px / JPEG quality 0.85 / 上限 2MB に圧縮してから送信
+- 既に上限以下の JPEG はスキップして再エンコードによる劣化を回避
+- `OotdNewPageClient` の `handleFileChange` で HEIC 変換後に圧縮処理を挟み、AI 分析・Storage アップロードの両経路で圧縮済み画像を使用（転送量も副次削減）
+- 寸法計算・スキップ判定・圧縮実行・URL リソース解放までユニットテスト 11 ケースでカバー
+
+---
+
 ### v0.9.4 — 2026-05-08
 
 **OOTD 投稿フローの離脱対策と Storage アップロード遅延化**

--- a/app/(public)/ootd/new/OotdNewPageClient.tsx
+++ b/app/(public)/ootd/new/OotdNewPageClient.tsx
@@ -13,6 +13,7 @@ import {
 import { ImageIcon, SparkleIcon } from "@/components/ui/icons";
 import { Spinner } from "@/components/ui/Spinner";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { compressImage } from "@/lib/image-compress";
 import type { OotdAnalysisResult } from "@/types/ootd";
 
 type Step = "upload" | "analysis" | "register";
@@ -111,9 +112,11 @@ export function OotdNewPageClient() {
     setIsPreparingFile(true);
 
     try {
-      const prepared = HEIC_TYPES.has(file.type.toLowerCase())
+      const heicConverted = HEIC_TYPES.has(file.type.toLowerCase())
         ? await convertHeicToJpegViaServer(file)
         : file;
+      // /api/ootd/analyze は Vercel の 4.5MB body limit を持つため、送信前に圧縮する。
+      const prepared = await compressImage(heicConverted);
       // 古い preview を捨てて新しい ObjectURL を作る。
       // useEffect の cleanup で前回 URL が revoke される。
       setPreviewUrl(URL.createObjectURL(prepared));

--- a/lib/image-compress.ts
+++ b/lib/image-compress.ts
@@ -1,0 +1,97 @@
+// クライアント側で画像をリサイズ・JPEG 再エンコードするユーティリティ。
+// /api/ootd/analyze は Vercel serverless function 経由で 4.5MB 上限があるため、
+// 送信前にここで確実に下回らせる。
+
+const DEFAULT_MAX_EDGE = 1920;
+const DEFAULT_QUALITY = 0.85;
+const DEFAULT_MAX_SIZE_BYTES = 2 * 1024 * 1024;
+const JPEG_MIME_TYPES = new Set(["image/jpeg", "image/jpg"]);
+
+export interface CompressImageOptions {
+  maxEdge?: number;
+  quality?: number;
+  maxSizeBytes?: number;
+}
+
+export function calculateResizedDimensions(
+  width: number,
+  height: number,
+  maxEdge: number,
+): { width: number; height: number } {
+  const longest = Math.max(width, height);
+  if (longest <= maxEdge) {
+    return { width, height };
+  }
+  const ratio = maxEdge / longest;
+  return {
+    width: Math.round(width * ratio),
+    height: Math.round(height * ratio),
+  };
+}
+
+export async function compressImage(
+  file: File,
+  options: CompressImageOptions = {},
+): Promise<File> {
+  const maxEdge = options.maxEdge ?? DEFAULT_MAX_EDGE;
+  const quality = options.quality ?? DEFAULT_QUALITY;
+  const maxSizeBytes = options.maxSizeBytes ?? DEFAULT_MAX_SIZE_BYTES;
+
+  // 既に上限以下の JPEG は再エンコード不要。canvas 経由で劣化させない。
+  if (
+    file.size <= maxSizeBytes &&
+    JPEG_MIME_TYPES.has(file.type.toLowerCase())
+  ) {
+    return file;
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const image = await loadImage(objectUrl);
+    const { width, height } = calculateResizedDimensions(
+      image.width,
+      image.height,
+      maxEdge,
+    );
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context is unavailable");
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = "high";
+    ctx.drawImage(image, 0, 0, width, height);
+
+    const blob = await canvasToJpegBlob(canvas, quality);
+    const baseName = file.name.replace(/\.[^.]+$/, "") || "image";
+    return new File([blob], `${baseName}.jpg`, { type: "image/jpeg" });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("Failed to load image"));
+    img.src = src;
+  });
+}
+
+function canvasToJpegBlob(
+  canvas: HTMLCanvasElement,
+  quality: number,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error("Failed to encode image"));
+      },
+      "image/jpeg",
+      quality,
+    );
+  });
+}

--- a/tests/unit/lib/image-compress.test.ts
+++ b/tests/unit/lib/image-compress.test.ts
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------------
+// lib/image-compress の振る舞いを検証する。
+// - calculateResizedDimensions: アスペクト比維持・上限縮小・拡大しない
+// - compressImage: 既に十分小さい JPEG は再エンコードしない
+// - compressImage: 大きい画像は max edge 1920 / quality 0.85 で JPEG 化する
+//
+// 注: jsdom には canvas/Image の実体が無いため、必要箇所をモックする。
+//     外部 I/O ではないが、ブラウザ API のみのコードはモック許可（外部API扱い）。
+// ---------------------------------------------------------------------------
+
+import {
+  calculateResizedDimensions,
+  compressImage,
+} from "@/lib/image-compress";
+
+describe("calculateResizedDimensions", () => {
+  it("max edge より大きい横長画像は max edge を長辺に縮小する", () => {
+    expect(calculateResizedDimensions(4000, 3000, 1920)).toEqual({
+      width: 1920,
+      height: 1440,
+    });
+  });
+
+  it("max edge より大きい縦長画像は max edge を長辺に縮小する", () => {
+    expect(calculateResizedDimensions(3000, 4000, 1920)).toEqual({
+      width: 1440,
+      height: 1920,
+    });
+  });
+
+  it("max edge と等しい画像はそのまま返す", () => {
+    expect(calculateResizedDimensions(1920, 1080, 1920)).toEqual({
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  it("max edge より小さい画像は拡大せずそのまま返す", () => {
+    expect(calculateResizedDimensions(1000, 500, 1920)).toEqual({
+      width: 1000,
+      height: 500,
+    });
+  });
+
+  it("正方形画像は両辺を max edge に揃える", () => {
+    expect(calculateResizedDimensions(3000, 3000, 1920)).toEqual({
+      width: 1920,
+      height: 1920,
+    });
+  });
+
+  it("結果の寸法は整数に丸められる", () => {
+    const r = calculateResizedDimensions(1921, 1080, 1920);
+    expect(Number.isInteger(r.width)).toBe(true);
+    expect(Number.isInteger(r.height)).toBe(true);
+  });
+});
+
+describe("compressImage (skip path)", () => {
+  it("既に上限以下の JPEG はそのまま返す（再エンコードしない）", async () => {
+    const small = new File(["x".repeat(100)], "small.jpg", {
+      type: "image/jpeg",
+    });
+    const result = await compressImage(small, {
+      maxSizeBytes: 2 * 1024 * 1024,
+    });
+    expect(result).toBe(small);
+  });
+
+  it("image/jpg (非標準) の MIME でもサイズ以下ならスキップする", async () => {
+    const small = new File(["x".repeat(100)], "small.jpg", {
+      type: "image/jpg",
+    });
+    const result = await compressImage(small, {
+      maxSizeBytes: 2 * 1024 * 1024,
+    });
+    expect(result).toBe(small);
+  });
+});
+
+describe("compressImage (compress path)", () => {
+  // canvas / Image / URL.createObjectURL を最低限モックする
+  const ORIGINAL_CREATE_OBJECT_URL = global.URL.createObjectURL;
+  const ORIGINAL_REVOKE_OBJECT_URL = global.URL.revokeObjectURL;
+  const ORIGINAL_IMAGE = global.Image;
+
+  beforeEach(() => {
+    global.URL.createObjectURL = vi.fn(() => "blob:mock");
+    global.URL.revokeObjectURL = vi.fn();
+
+    // Image: src を代入したら次のティックで onload を発火する偽物
+    class FakeImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      width = 4000;
+      height = 3000;
+      private _src = "";
+      get src() {
+        return this._src;
+      }
+      set src(value: string) {
+        this._src = value;
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    // @ts-expect-error テスト用差し替え
+    global.Image = FakeImage;
+
+    // canvas.getContext / toBlob の偽実装
+    const fakeCtx = {
+      drawImage: vi.fn(),
+      imageSmoothingEnabled: true,
+      imageSmoothingQuality: "high",
+    };
+    HTMLCanvasElement.prototype.getContext = vi.fn(
+      () => fakeCtx,
+    ) as unknown as HTMLCanvasElement["getContext"];
+    HTMLCanvasElement.prototype.toBlob = function (
+      cb: BlobCallback,
+      type?: string,
+    ) {
+      // 圧縮後の小さい Blob を返す
+      cb(new Blob(["compressed"], { type: type ?? "image/jpeg" }));
+    } as HTMLCanvasElement["toBlob"];
+  });
+
+  afterEach(() => {
+    global.URL.createObjectURL = ORIGINAL_CREATE_OBJECT_URL;
+    global.URL.revokeObjectURL = ORIGINAL_REVOKE_OBJECT_URL;
+    global.Image = ORIGINAL_IMAGE;
+    vi.restoreAllMocks();
+  });
+
+  it("上限超え JPEG は image/jpeg の File として再エンコードして返す", async () => {
+    const big = new File(["x".repeat(3 * 1024 * 1024)], "big.jpg", {
+      type: "image/jpeg",
+    });
+    const result = await compressImage(big, {
+      maxEdge: 1920,
+      quality: 0.85,
+      maxSizeBytes: 2 * 1024 * 1024,
+    });
+    expect(result).toBeInstanceOf(File);
+    expect(result.type).toBe("image/jpeg");
+    expect(result.size).toBeLessThan(big.size);
+  });
+
+  it("PNG 入力でも JPEG として再エンコードし、拡張子を .jpg に正規化する", async () => {
+    const big = new File(["x".repeat(3 * 1024 * 1024)], "photo.png", {
+      type: "image/png",
+    });
+    const result = await compressImage(big, {
+      maxEdge: 1920,
+      quality: 0.85,
+      maxSizeBytes: 2 * 1024 * 1024,
+    });
+    expect(result.type).toBe("image/jpeg");
+    expect(result.name).toMatch(/\.jpg$/);
+  });
+
+  it("ObjectURL は処理後に revoke される（リーク防止）", async () => {
+    const big = new File(["x".repeat(3 * 1024 * 1024)], "big.jpg", {
+      type: "image/jpeg",
+    });
+    await compressImage(big, { maxSizeBytes: 2 * 1024 * 1024 });
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock");
+  });
+});


### PR DESCRIPTION
## 変更の概要

OOTD 投稿フローで写真選択時に、クライアント側で画像をリサイズ・JPEG 再エンコードしてから `/api/ootd/analyze` に送信するようにする。

## 変更の理由

iPhone で撮影した HEIC をサーバーで JPEG 変換すると素で 5〜8MB を超え、Vercel serverless function の **4.5MB body size 上限** を突破できないケースが発生していた。

このとき Route Handler に到達する前段で `Request Entity Too Large` がプレーンテキストで返り、クライアント側の `response.json()` が以下のエラーで死ぬ:

```
Unexpected token 'R', "Request En"... is not valid JSON
```

クライアントで確実にサイズを下回らせることで根本解決する。

## 変更内容

- **新規** `lib/image-compress.ts`
  - `calculateResizedDimensions(width, height, maxEdge)` — 純粋関数。アスペクト比維持・拡大なし・整数丸め
  - `compressImage(file, options?)` — canvas 経由で max edge 1920px / JPEG quality 0.85 にリサイズ。既に上限以下の JPEG はスキップ
- **修正** `app/(public)/ootd/new/OotdNewPageClient.tsx`
  - `handleFileChange` の HEIC 変換後に `compressImage` を挟む
  - 圧縮済みファイルが `selectedFile` として保持され、AI 分析・Storage アップロード両方で使われる
- **新規** `tests/unit/lib/image-compress.test.ts` — 11 ケース（次元計算 6 / skip path 2 / compress path 3）

## テスト方法

- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test -- --run` — 169 passed
- [x] `npm run build` — pass
- [ ] 手動: 大容量 HEIC（5MB 超）で OOTD 投稿し、413 が出ないこと
- [ ] 手動: 小容量 JPEG（<2MB）で再エンコードがスキップされ、画質劣化しないこと

## 影響範囲

- `app/(public)/ootd/new` 配下のアップロードフローのみ
- AI 分析・Storage アップロード共に圧縮済み画像を使うため、転送量も副次的に削減される
- 既存サーバー側 10MB ガード（`app/api/ootd/analyze/route.ts:52-60`）はそのまま残す（保険）
- 既存の HEIC→JPEG 変換 API は変更なし

## チェックリスト

- [ ] コードレビューを依頼した
- [x] テストが完了している
- [x] ドキュメントを更新した（必要に応じて）
- [x] コミットメッセージが適切である

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 画像の自動圧縮機能を追加しました。ファイルサイズを最適化し、より高速なアップロードと処理を実現します。

* **テスト**
  * 画像圧縮機能の包括的なユニットテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fune6900/DIG/pull/39)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->