### PR TITLE
feat: edit OOTD date and tags from detail

### DIFF
--- a/app/(public)/ootd/[id]/edit/OotdEditPageClient.tsx
+++ b/app/(public)/ootd/[id]/edit/OotdEditPageClient.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { OotdEditForm } from "@/components/features/ootd/OotdEditForm";
+import { ChevronLeftIcon } from "@/components/ui/icons";
+import { updateOotdAction } from "@/app/actions/ootd";
+import type { Ootd } from "@/types/ootd";
+
+interface OotdEditPageClientProps {
+  ootd: Ootd;
+}
+
+export function OotdEditPageClient({ ootd }: OotdEditPageClientProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  function goBackToDetail() {
+    router.push(`/ootd/${ootd.id}`);
+  }
+
+  async function handleSubmit(data: { date: Date; tags: string[] }) {
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    const result = await updateOotdAction(ootd.id, data);
+    setIsSubmitting(false);
+    if (result.error) {
+      setErrorMessage("保存に失敗した。時間を置いて再試行してくれ。");
+      return;
+    }
+    router.push(`/ootd/${ootd.id}`);
+    router.refresh();
+  }
+
+  return (
+    <article className="mx-auto max-w-2xl space-y-8">
+      <header className="space-y-3">
+        <button
+          type="button"
+          onClick={goBackToDetail}
+          aria-label="戻る"
+          className="inline-flex items-center gap-1 text-xs font-medium tracking-widest uppercase text-denim/50 hover:text-denim dark:text-offwhite/40 dark:hover:text-offwhite transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 rounded-sm"
+        >
+          <ChevronLeftIcon width={14} height={14} />
+          戻る
+        </button>
+        <h1 className="font-display text-2xl tracking-widest text-denim-dark dark:text-offwhite leading-tight">
+          投稿の編集
+        </h1>
+      </header>
+
+      {errorMessage && (
+        <p
+          role="alert"
+          className="rounded-sm border border-rust/30 dark:border-rust-light/30 bg-rust/5 dark:bg-rust-light/5 px-3 py-2 text-sm text-rust dark:text-rust-light"
+        >
+          {errorMessage}
+        </p>
+      )}
+
+      <OotdEditForm
+        ootd={ootd}
+        onSubmit={handleSubmit}
+        onCancel={goBackToDetail}
+        isSubmitting={isSubmitting}
+      />
+    </article>
+  );
+}

--- a/app/(public)/ootd/[id]/edit/page.tsx
+++ b/app/(public)/ootd/[id]/edit/page.tsx
@@ -1,0 +1,33 @@
+export const dynamic = "force-dynamic";
+
+import { notFound } from "next/navigation";
+import { getOotdByIdAction } from "@/app/actions/ootd";
+import { OotdEditPageClient } from "./OotdEditPageClient";
+
+interface OotdEditRouteProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function OotdEditRoute({ params }: OotdEditRouteProps) {
+  const { id } = await params;
+  const result = await getOotdByIdAction(id);
+
+  if (
+    result.error?.code === "NOT_FOUND" ||
+    result.error?.code === "VALIDATION_ERROR"
+  ) {
+    notFound();
+  }
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  const ootd = result.data!;
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
+      <OotdEditPageClient ootd={ootd} />
+    </main>
+  );
+}

--- a/app/actions/ootd.ts
+++ b/app/actions/ootd.ts
@@ -1,15 +1,21 @@
 "use server";
 
 import { z } from "zod";
+import { revalidatePath } from "next/cache";
 import {
   findOotds,
   findOotdById,
   createOotd,
   deleteOotd,
+  updateOotd,
 } from "@/services/ootd-service";
 import { prisma } from "@/lib/prisma";
 import { deleteImage } from "@/lib/storage";
-import { CreateOotdInputSchema, SortOrderSchema } from "@/types/ootd";
+import {
+  CreateOotdInputSchema,
+  SortOrderSchema,
+  UpdateOotdInputSchema,
+} from "@/types/ootd";
 import type { Ootd } from "@/types/ootd";
 
 type ActionResult<T> =
@@ -82,6 +88,38 @@ export async function createOotdAction(
     return { data: result, error: null };
   } catch (error) {
     console.error("[createOotdAction]", error);
+    return {
+      data: null,
+      error: { message: "Internal server error", code: "INTERNAL_ERROR" },
+    };
+  }
+}
+
+export async function updateOotdAction(
+  id: unknown,
+  input: unknown,
+): Promise<ActionResult<Ootd>> {
+  const idParsed = z.string().uuid().safeParse(id);
+  if (!idParsed.success) {
+    return {
+      data: null,
+      error: { message: "Invalid ID", code: "VALIDATION_ERROR" },
+    };
+  }
+  const inputParsed = UpdateOotdInputSchema.safeParse(input);
+  if (!inputParsed.success) {
+    return {
+      data: null,
+      error: { message: "Invalid input", code: "VALIDATION_ERROR" },
+    };
+  }
+  try {
+    const result = await updateOotd(idParsed.data, inputParsed.data);
+    revalidatePath("/ootd");
+    revalidatePath(`/ootd/${idParsed.data}`);
+    return { data: result, error: null };
+  } catch (error) {
+    console.error("[updateOotdAction]", error);
     return {
       data: null,
       error: { message: "Internal server error", code: "INTERNAL_ERROR" },

--- a/components/features/ootd/OotdDetail.tsx
+++ b/components/features/ootd/OotdDetail.tsx
@@ -3,12 +3,18 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import Image from "next/image";
+import Link from "next/link";
 import { Badge } from "@/components/ui/Badge";
 import { OotdColorPalette } from "@/components/features/ootd/OotdColorPalette";
 import { OotdStyleGauge } from "@/components/features/ootd/OotdStyleGauge";
 import { OotdItemList } from "@/components/features/ootd/OotdItemList";
 import { OotdEvaluationRadar } from "@/components/features/ootd/OotdEvaluationRadar";
-import { ChevronLeftIcon, CloseIcon, TrashIcon } from "@/components/ui/icons";
+import {
+  ChevronLeftIcon,
+  CloseIcon,
+  PencilIcon,
+  TrashIcon,
+} from "@/components/ui/icons";
 import type { Ootd } from "@/types/ootd";
 
 interface OotdDetailProps {
@@ -61,12 +67,33 @@ export function OotdDetail({ ootd, onDelete, onBack }: OotdDetailProps) {
           <h1 className="font-display text-3xl tracking-widest text-denim-dark dark:text-offwhite leading-tight">
             {ootd.oneLiner}
           </h1>
-          <time
-            dateTime={ootd.date.toISOString()}
-            className="block text-sm text-denim/50 dark:text-offwhite/40"
-          >
-            {formattedDate}
-          </time>
+          <div className="flex items-center justify-between gap-3">
+            <time
+              dateTime={ootd.date.toISOString()}
+              className="block text-sm text-denim/50 dark:text-offwhite/40"
+            >
+              {formattedDate}
+            </time>
+            <div className="flex items-center gap-2">
+              <Link
+                href={`/ootd/${ootd.id}/edit`}
+                aria-label="編集"
+                className="inline-flex items-center gap-1.5 rounded-sm px-3 py-1.5 text-xs font-medium text-denim/70 dark:text-offwhite/60 border border-denim/20 dark:border-offwhite/20 hover:bg-denim/5 dark:hover:bg-offwhite/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2"
+              >
+                <PencilIcon width={12} height={12} />
+                編集
+              </Link>
+              <button
+                type="button"
+                onClick={() => setShowConfirm(true)}
+                aria-label="削除"
+                className="inline-flex items-center gap-1.5 rounded-sm px-3 py-1.5 text-xs font-medium text-rust dark:text-rust-light border border-rust/30 dark:border-rust-light/30 hover:bg-rust/5 dark:hover:bg-rust-light/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rust focus-visible:ring-offset-2"
+              >
+                <TrashIcon width={12} height={12} />
+                削除
+              </button>
+            </div>
+          </div>
           {ootd.tags.length > 0 && (
             <div className="flex flex-wrap gap-1.5">
               {ootd.tags.map((tag) => (
@@ -129,18 +156,6 @@ export function OotdDetail({ ootd, onDelete, onBack }: OotdDetailProps) {
             <OotdEvaluationRadar scores={ootd.radarScores} />
           </section>
         )}
-
-        <div className="pt-4 border-t border-denim/10 dark:border-offwhite/10">
-          <button
-            type="button"
-            onClick={() => setShowConfirm(true)}
-            aria-label="削除"
-            className="inline-flex items-center gap-1.5 rounded-sm px-4 py-2 text-sm font-medium text-rust dark:text-rust-light border border-rust/30 dark:border-rust-light/30 hover:bg-rust/5 dark:hover:bg-rust-light/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rust focus-visible:ring-offset-2"
-          >
-            <TrashIcon width={14} height={14} />
-            削除
-          </button>
-        </div>
       </article>
 
       {showConfirm &&

--- a/components/features/ootd/OotdEditForm.tsx
+++ b/components/features/ootd/OotdEditForm.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+import { CheckIcon, CloseIcon, PlusIcon } from "@/components/ui/icons";
+import { Spinner } from "@/components/ui/Spinner";
+import type { Ootd } from "@/types/ootd";
+
+interface OotdEditFormProps {
+  ootd: Ootd;
+  onSubmit: (data: { date: Date; tags: string[] }) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+const MAX_TAGS = 3;
+const DATE_PATTERN = /^(\d{4})\/(\d{2})\/(\d{2})$/;
+
+export function formatDateInput(date: Date): string {
+  const y = date.getFullYear().toString().padStart(4, "0");
+  const m = (date.getMonth() + 1).toString().padStart(2, "0");
+  const d = date.getDate().toString().padStart(2, "0");
+  return `${y}/${m}/${d}`;
+}
+
+export function parseDateInput(value: string): Date | null {
+  const match = DATE_PATTERN.exec(value.trim());
+  if (!match) return null;
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  const date = new Date(y, m - 1, d);
+  if (
+    date.getFullYear() !== y ||
+    date.getMonth() !== m - 1 ||
+    date.getDate() !== d
+  ) {
+    return null;
+  }
+  return date;
+}
+
+export function OotdEditForm({
+  ootd,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: OotdEditFormProps) {
+  const [dateValue, setDateValue] = useState(formatDateInput(ootd.date));
+  const [tags, setTags] = useState<string[]>(ootd.tags);
+  const [tagInput, setTagInput] = useState("");
+  const [dateError, setDateError] = useState<string | null>(null);
+
+  function handleAddTag() {
+    const trimmed = tagInput.trim().replace(/^#/, "");
+    if (!trimmed || tags.length >= MAX_TAGS || tags.includes(trimmed)) {
+      return;
+    }
+    setTags((prev) => [...prev, trimmed]);
+    setTagInput("");
+  }
+
+  function handleRemoveTag(tag: string) {
+    setTags((prev) => prev.filter((t) => t !== tag));
+  }
+
+  function handleTagKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddTag();
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const parsed = parseDateInput(dateValue);
+    if (!parsed) {
+      setDateError("YYYY/MM/DD 形式で入力してください");
+      return;
+    }
+    setDateError(null);
+    onSubmit({ date: parsed, tags });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-1.5">
+        <label
+          htmlFor="ootd-edit-date"
+          className="text-xs font-bold tracking-widest uppercase text-denim/40 dark:text-offwhite/30"
+        >
+          投稿年月日
+        </label>
+        <input
+          id="ootd-edit-date"
+          type="text"
+          inputMode="numeric"
+          value={dateValue}
+          onChange={(e) => setDateValue(e.target.value)}
+          placeholder="2026/05/12"
+          maxLength={10}
+          aria-invalid={dateError !== null}
+          aria-describedby={dateError ? "ootd-edit-date-error" : undefined}
+          className="w-full rounded-sm border border-denim/15 bg-offwhite dark:bg-canvas-subtle px-3 py-2 text-sm text-denim-dark dark:text-offwhite focus:outline-none focus:ring-2 focus:ring-denim focus:ring-offset-1"
+        />
+        {dateError && (
+          <p
+            id="ootd-edit-date-error"
+            role="alert"
+            className="text-xs text-rust dark:text-rust-light"
+          >
+            {dateError}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-xs font-bold tracking-widest uppercase text-denim/40 dark:text-offwhite/30">
+          タグ{" "}
+          <span className="text-denim/30 dark:text-offwhite/20 normal-case tracking-normal">
+            （最大{MAX_TAGS}つ）
+          </span>
+        </label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={handleTagKeyDown}
+            placeholder="タグを入力（例: 古着）"
+            disabled={tags.length >= MAX_TAGS}
+            maxLength={30}
+            className="flex-1 rounded-sm border border-denim/15 bg-offwhite dark:bg-canvas-subtle px-3 py-2 text-sm text-denim-dark dark:text-offwhite placeholder:text-denim/30 dark:placeholder:text-offwhite/20 focus:outline-none focus:ring-2 focus:ring-denim focus:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+          />
+          <button
+            type="button"
+            onClick={handleAddTag}
+            disabled={tags.length >= MAX_TAGS || !tagInput.trim()}
+            className="inline-flex items-center gap-1.5 rounded-sm bg-denim px-4 py-2 text-sm font-medium text-offwhite hover:bg-denim-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2"
+          >
+            <PlusIcon width={14} height={14} />
+            追加
+          </button>
+        </div>
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-2 pt-1">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 rounded-sm bg-denim/10 dark:bg-denim-light/10 px-2.5 py-1 text-xs font-medium text-denim-dark dark:text-offwhite"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => handleRemoveTag(tag)}
+                  aria-label={`${tag}を削除`}
+                  className="text-denim/40 hover:text-rust dark:text-offwhite/40 dark:hover:text-rust-light transition-colors"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-sm border border-denim/20 dark:border-offwhite/20 px-4 py-2.5 text-sm font-medium text-denim/70 dark:text-offwhite/60 hover:bg-denim/5 dark:hover:bg-offwhite/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2"
+        >
+          <CloseIcon width={14} height={14} />
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-sm bg-denim px-4 py-2.5 text-sm font-medium tracking-widest text-offwhite hover:bg-denim-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2"
+        >
+          {isSubmitting ? (
+            <>
+              <Spinner size="sm" variant="light" />
+              保存中...
+            </>
+          ) : (
+            <>
+              <CheckIcon width={14} height={14} />
+              保存
+            </>
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -151,6 +151,15 @@ export function CheckIcon(props: IconProps) {
   );
 }
 
+export function PencilIcon(props: IconProps) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" {...baseProps} {...props}>
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+    </svg>
+  );
+}
+
 export function ArrowRightIcon(props: IconProps) {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" {...baseProps} {...props}>

--- a/services/ootd-service.ts
+++ b/services/ootd-service.ts
@@ -6,6 +6,7 @@ import {
   DetectedItemSchema,
   EvaluationRadarSchema,
   CreateOotdInput,
+  UpdateOotdInput,
 } from "@/types/ootd";
 import type { Ootd, SortOrder } from "@/types/ootd";
 import { Prisma } from "@prisma/client";
@@ -95,6 +96,20 @@ export async function createOotd(
       radarScores: input.radarScores ?? Prisma.JsonNull,
       tags: input.tags,
       ...(input.date !== undefined ? { date: input.date } : {}),
+    },
+  });
+  return parseOotdRecord(record);
+}
+
+export async function updateOotd(
+  id: string,
+  input: UpdateOotdInput,
+): Promise<Ootd> {
+  const record = await prisma.ootd.update({
+    where: { id },
+    data: {
+      date: input.date,
+      tags: input.tags,
     },
   });
   return parseOotdRecord(record);

--- a/tests/unit/components/OotdDetail.test.tsx
+++ b/tests/unit/components/OotdDetail.test.tsx
@@ -104,4 +104,13 @@ describe("OotdDetail", () => {
       "123e4567-e89b-12d3-a456-426614174000",
     );
   });
+
+  it("編集リンクが /ootd/{id}/edit を指す", () => {
+    render(<OotdDetail ootd={mockOotd} onDelete={vi.fn()} />);
+    const editLink = screen.getByRole("link", { name: "編集" });
+    expect(editLink).toHaveAttribute(
+      "href",
+      "/ootd/123e4567-e89b-12d3-a456-426614174000/edit",
+    );
+  });
 });

--- a/tests/unit/components/OotdEditForm.test.tsx
+++ b/tests/unit/components/OotdEditForm.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { OotdEditForm } from "@/components/features/ootd/OotdEditForm";
+import type { Ootd } from "@/types/ootd";
+
+const mockOotd: Ootd = {
+  id: "123e4567-e89b-12d3-a456-426614174000",
+  imageUrl: "https://example.com/ootd.jpg",
+  oneLiner: "ヴィンテージデニムで決めた今日のコーデ",
+  colorPalette: [],
+  styles: [],
+  description: "test",
+  detectedItems: [],
+  date: new Date("2026-05-12T00:00:00Z"),
+  tags: ["古着", "デニム"],
+  createdAt: new Date("2026-05-12T10:00:00Z"),
+  updatedAt: new Date("2026-05-12T10:00:00Z"),
+};
+
+describe("OotdEditForm", () => {
+  it("初期表示で日付が YYYY/MM/DD 形式で表示される", () => {
+    render(
+      <OotdEditForm
+        ootd={mockOotd}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    const dateInput = screen.getByLabelText(/投稿年月日/) as HTMLInputElement;
+    expect(dateInput.value).toBe("2026/05/12");
+  });
+
+  it("初期表示でタグが # なしで表示される", () => {
+    render(
+      <OotdEditForm
+        ootd={mockOotd}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    expect(screen.getByText("古着")).toBeInTheDocument();
+    expect(screen.getByText("デニム")).toBeInTheDocument();
+    expect(screen.queryByText("#古着")).not.toBeInTheDocument();
+    expect(screen.queryByText("#デニム")).not.toBeInTheDocument();
+  });
+
+  it("保存ボタンで onSubmit が呼ばれる（変更なし）", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <OotdEditForm
+        ootd={mockOotd}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /保存/ }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const arg = onSubmit.mock.calls[0][0];
+    expect(arg.date).toBeInstanceOf(Date);
+    expect(arg.tags).toEqual(["古着", "デニム"]);
+  });
+
+  it("日付を変更して保存すると新しい Date が onSubmit に渡る", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <OotdEditForm
+        ootd={mockOotd}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    const dateInput = screen.getByLabelText(/投稿年月日/);
+    await userEvent.clear(dateInput);
+    await userEvent.type(dateInput, "2026/06/01");
+    await userEvent.click(screen.getByRole("button", { name: /保存/ }));
+    const arg = onSubmit.mock.calls[0][0];
+    expect(arg.date.getFullYear()).toBe(2026);
+    expect(arg.date.getMonth()).toBe(5);
+    expect(arg.date.getDate()).toBe(1);
+  });
+
+  it("不正な日付形式ではエラーが表示され onSubmit が呼ばれない", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <OotdEditForm
+        ootd={mockOotd}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    const dateInput = screen.getByLabelText(/投稿年月日/);
+    await userEvent.clear(dateInput);
+    await userEvent.type(dateInput, "not-a-date");
+    await userEvent.click(screen.getByRole("button", { name: /保存/ }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("タグ削除ボタンでタグが削除される", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <OotdEditForm
+        ootd={mockOotd}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "古着を削除" }));
+    await userEvent.click(screen.getByRole("button", { name: /保存/ }));
+    expect(onSubmit.mock.calls[0][0].tags).toEqual(["デニム"]);
+  });
+
+  it("タグを追加して保存できる", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <OotdEditForm
+        ootd={mockOotd}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
+    const tagInput = screen.getByPlaceholderText(/タグを入力/);
+    await userEvent.type(tagInput, "90s");
+    await userEvent.click(screen.getByRole("button", { name: "追加" }));
+    await userEvent.click(screen.getByRole("button", { name: /保存/ }));
+    expect(onSubmit.mock.calls[0][0].tags).toEqual(["古着", "デニム", "90s"]);
+  });
+
+  it("キャンセルボタンで onCancel が呼ばれる", async () => {
+    const onCancel = vi.fn();
+    render(
+      <OotdEditForm
+        ootd={mockOotd}
+        onSubmit={vi.fn()}
+        onCancel={onCancel}
+        isSubmitting={false}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/services/ootd-schema.test.ts
+++ b/tests/unit/services/ootd-schema.test.ts
@@ -5,6 +5,7 @@ import {
   DetectedItemSchema,
   CreateOotdInputSchema,
   EvaluationRadarSchema,
+  UpdateOotdInputSchema,
 } from "@/types/ootd";
 
 // ---------------------------------------------------------------------------
@@ -404,5 +405,60 @@ describe("CreateOotdInputSchema", () => {
       expect((result.data as Record<string, unknown>)["id"]).toBeUndefined();
     }
     // strict モードで fail する場合も可（設計次第）
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UpdateOotdInputSchema
+// ---------------------------------------------------------------------------
+describe("UpdateOotdInputSchema", () => {
+  const validUpdate = {
+    date: new Date("2026-05-12"),
+    tags: ["古着", "デニム"],
+  };
+
+  it("正常値（date + tags）でパースできる", () => {
+    const result = UpdateOotdInputSchema.safeParse(validUpdate);
+    expect(result.success).toBe(true);
+  });
+
+  it("date が Date 型でなければバリデーションエラーになる", () => {
+    const result = UpdateOotdInputSchema.safeParse({
+      ...validUpdate,
+      date: "2026-05-12",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("tags が空配列でパースできる", () => {
+    const result = UpdateOotdInputSchema.safeParse({
+      ...validUpdate,
+      tags: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("tags が 3 つでパースできる（上限境界値）", () => {
+    const result = UpdateOotdInputSchema.safeParse({
+      ...validUpdate,
+      tags: ["古着", "デニム", "90s"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("tags が 4 つでバリデーションエラーになる（上限超過）", () => {
+    const result = UpdateOotdInputSchema.safeParse({
+      ...validUpdate,
+      tags: ["古着", "デニム", "90s", "アメカジ"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("tags の要素が空文字でバリデーションエラーになる", () => {
+    const result = UpdateOotdInputSchema.safeParse({
+      ...validUpdate,
+      tags: [""],
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/tests/unit/services/ootd-service.test.ts
+++ b/tests/unit/services/ootd-service.test.ts
@@ -3,6 +3,7 @@ import {
   findOotdById,
   createOotd,
   deleteOotd,
+  updateOotd,
 } from "@/services/ootd-service";
 
 // ---------------------------------------------------------------------------
@@ -19,6 +20,7 @@ vi.mock("@/lib/prisma", () => ({
       findUnique: vi.fn(),
       create: vi.fn(),
       delete: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));
@@ -220,5 +222,52 @@ describe("deleteOotd", () => {
       where: { id: "uuid-a" },
     });
     expect(prisma.ootd.delete).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateOotd
+// ---------------------------------------------------------------------------
+describe("updateOotd", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("date と tags を更新して結果を返す", async () => {
+    const newDate = new Date("2026-05-12");
+    const newTags = ["古着", "リメイク"];
+    const updated = {
+      ...FIXTURE_A,
+      date: newDate,
+      tags: newTags,
+    };
+    vi.mocked(prisma.ootd.update).mockResolvedValue(updated);
+
+    const result = await updateOotd("uuid-a", {
+      date: newDate,
+      tags: newTags,
+    });
+
+    expect(prisma.ootd.update).toHaveBeenCalledWith({
+      where: { id: "uuid-a" },
+      data: { date: newDate, tags: newTags },
+    });
+    expect(result.date).toEqual(newDate);
+    expect(result.tags).toEqual(newTags);
+  });
+
+  it("空配列のタグでも更新できる", async () => {
+    const updated = {
+      ...FIXTURE_A,
+      tags: [],
+    };
+    vi.mocked(prisma.ootd.update).mockResolvedValue(updated);
+
+    const result = await updateOotd("uuid-a", {
+      date: FIXTURE_A.date,
+      tags: [],
+    });
+
+    expect(result.tags).toEqual([]);
   });
 });

--- a/types/ootd.ts
+++ b/types/ootd.ts
@@ -83,6 +83,12 @@ export const CreateOotdInputSchema = z.object({
 });
 export type CreateOotdInput = z.infer<typeof CreateOotdInputSchema>;
 
+export const UpdateOotdInputSchema = z.object({
+  date: z.date(),
+  tags: z.array(z.string().min(1)).max(3),
+});
+export type UpdateOotdInput = z.infer<typeof UpdateOotdInputSchema>;
+
 export const OotdListItemSchema = OotdSchema.pick({
   id: true,
   imageUrl: true,


### PR DESCRIPTION
## 変更の概要
OOTD詳細画面に編集機能を追加。日付とタグを更新できる。

Closes #42

## 変更の理由
過去の投稿に対して、後から投稿日付やタグを修正できるようにするため。

## 変更内容
- `types/ootd.ts`: `UpdateOotdInputSchema` 追加
- `services/ootd-service.ts`: `updateOotd(id, input)` 追加
- `app/actions/ootd.ts`: `updateOotdAction` 追加（Zod 検証 + revalidatePath）
- `components/features/ootd/OotdDetail.tsx`:
  - 日付行の右端に「編集」リンクと「削除」ボタンを配置
  - 既存の最下部削除ボタンを削除
- `components/features/ootd/OotdEditForm.tsx`: 新規。日付（YYYY/MM/DD 形式）・タグ（# 無し）の編集フォーム
- `app/(public)/ootd/[id]/edit/`: 新規ルート
- `components/ui/icons.tsx`: `PencilIcon` 追加

## テスト方法
- `npm test -- --run` 全件グリーン（200 件）
- `npm run typecheck` / `npm run lint` / `npm run build` 全て通過
- 詳細画面の「編集」を押下 → 編集フォームに遷移 → 日付/タグを変更 → 保存 → 詳細画面に戻り反映を確認

## 影響範囲
- 詳細画面のヘッダーレイアウト変更（既存の「削除」ボタンは bottom セクションから日付行に移動）
- `OotdDetailModal` も内部で `OotdDetail` を使用しているため、モーダル経由の編集リンクも有効

## チェックリスト
- [x] コードレビューを依頼した
- [x] テストが完了している
- [ ] ドキュメントを更新した（必要に応じて）
- [x] コミットメッセージが適切である

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * OOTDの日付とタグを編集できるようになりました
  * OOTDの詳細ページに編集ボタンを追加しました
  * 編集フォームで日付（YYYY/MM/DD形式）とタグ（最大3個）を変更できます

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fune6900/DIG/pull/43)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->