### PR TITLE
feat: use native date picker for OOTD edit

### DIFF
--- a/components/features/ootd/OotdEditForm.tsx
+++ b/components/features/ootd/OotdEditForm.tsx
@@ -13,17 +13,19 @@ interface OotdEditFormProps {
 }
 
 const MAX_TAGS = 3;
-const DATE_PATTERN = /^(\d{4})\/(\d{2})\/(\d{2})$/;
+// `<input type="date">` の value は ISO 8601 ローカル日付 (YYYY-MM-DD)。
+// JS の Date とのやり取りはローカルタイムで行い UTC ずれを避ける。
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 export function formatDateInput(date: Date): string {
   const y = date.getFullYear().toString().padStart(4, "0");
   const m = (date.getMonth() + 1).toString().padStart(2, "0");
   const d = date.getDate().toString().padStart(2, "0");
-  return `${y}/${m}/${d}`;
+  return `${y}-${m}-${d}`;
 }
 
 export function parseDateInput(value: string): Date | null {
-  const match = DATE_PATTERN.exec(value.trim());
+  const match = ISO_DATE_PATTERN.exec(value.trim());
   if (!match) return null;
   const y = Number(match[1]);
   const m = Number(match[2]);
@@ -74,7 +76,7 @@ export function OotdEditForm({
     e.preventDefault();
     const parsed = parseDateInput(dateValue);
     if (!parsed) {
-      setDateError("YYYY/MM/DD 形式で入力してください");
+      setDateError("有効な日付を選択してください");
       return;
     }
     setDateError(null);
@@ -92,12 +94,9 @@ export function OotdEditForm({
         </label>
         <input
           id="ootd-edit-date"
-          type="text"
-          inputMode="numeric"
+          type="date"
           value={dateValue}
           onChange={(e) => setDateValue(e.target.value)}
-          placeholder="2026/05/12"
-          maxLength={10}
           aria-invalid={dateError !== null}
           aria-describedby={dateError ? "ootd-edit-date-error" : undefined}
           className="w-full rounded-sm border border-denim/15 bg-offwhite dark:bg-canvas-subtle px-3 py-2 text-sm text-denim-dark dark:text-offwhite focus:outline-none focus:ring-2 focus:ring-denim focus:ring-offset-1"

--- a/tests/unit/components/OotdEditForm.test.tsx
+++ b/tests/unit/components/OotdEditForm.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { OotdEditForm } from "@/components/features/ootd/OotdEditForm";
 import type { Ootd } from "@/types/ootd";
 
+// 日付は local-time コンストラクタで作成。TZ ずれを避けるため。
 const mockOotd: Ootd = {
   id: "123e4567-e89b-12d3-a456-426614174000",
   imageUrl: "https://example.com/ootd.jpg",
@@ -11,14 +12,14 @@ const mockOotd: Ootd = {
   styles: [],
   description: "test",
   detectedItems: [],
-  date: new Date("2026-05-12T00:00:00Z"),
+  date: new Date(2026, 4, 12),
   tags: ["古着", "デニム"],
-  createdAt: new Date("2026-05-12T10:00:00Z"),
-  updatedAt: new Date("2026-05-12T10:00:00Z"),
+  createdAt: new Date(2026, 4, 12, 10),
+  updatedAt: new Date(2026, 4, 12, 10),
 };
 
 describe("OotdEditForm", () => {
-  it("初期表示で日付が YYYY/MM/DD 形式で表示される", () => {
+  it("初期表示で日付が ISO 形式 (YYYY-MM-DD) で input に入る", () => {
     render(
       <OotdEditForm
         ootd={mockOotd}
@@ -28,7 +29,8 @@ describe("OotdEditForm", () => {
       />,
     );
     const dateInput = screen.getByLabelText(/投稿年月日/) as HTMLInputElement;
-    expect(dateInput.value).toBe("2026/05/12");
+    expect(dateInput.type).toBe("date");
+    expect(dateInput.value).toBe("2026-05-12");
   });
 
   it("初期表示でタグが # なしで表示される", () => {
@@ -63,7 +65,7 @@ describe("OotdEditForm", () => {
     expect(arg.tags).toEqual(["古着", "デニム"]);
   });
 
-  it("日付を変更して保存すると新しい Date が onSubmit に渡る", async () => {
+  it("カレンダーで日付を変更して保存すると新しい Date が onSubmit に渡る", async () => {
     const onSubmit = vi.fn();
     render(
       <OotdEditForm
@@ -74,8 +76,7 @@ describe("OotdEditForm", () => {
       />,
     );
     const dateInput = screen.getByLabelText(/投稿年月日/);
-    await userEvent.clear(dateInput);
-    await userEvent.type(dateInput, "2026/06/01");
+    fireEvent.change(dateInput, { target: { value: "2026-06-01" } });
     await userEvent.click(screen.getByRole("button", { name: /保存/ }));
     const arg = onSubmit.mock.calls[0][0];
     expect(arg.date.getFullYear()).toBe(2026);
@@ -83,7 +84,7 @@ describe("OotdEditForm", () => {
     expect(arg.date.getDate()).toBe(1);
   });
 
-  it("不正な日付形式ではエラーが表示され onSubmit が呼ばれない", async () => {
+  it("日付が空のまま保存するとエラーが表示され onSubmit が呼ばれない", async () => {
     const onSubmit = vi.fn();
     render(
       <OotdEditForm
@@ -94,8 +95,7 @@ describe("OotdEditForm", () => {
       />,
     );
     const dateInput = screen.getByLabelText(/投稿年月日/);
-    await userEvent.clear(dateInput);
-    await userEvent.type(dateInput, "not-a-date");
+    fireEvent.change(dateInput, { target: { value: "" } });
     await userEvent.click(screen.getByRole("button", { name: /保存/ }));
     expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.getByRole("alert")).toBeInTheDocument();


### PR DESCRIPTION
## 変更の概要
OOTD編集画面の投稿年月日入力をカレンダーUI（HTML5 \`<input type=\"date\">\`）に変更。

Closes #44

## 変更の理由
テキスト入力では誤入力やフォーマット違反が発生しやすい。ネイティブの日付ピッカーで操作性と確実性を上げる。

## 変更内容
- \`components/features/ootd/OotdEditForm.tsx\`:
  - input を \`type=\"date\"\` に変更
  - 内部値を ISO 形式 (YYYY-MM-DD) で扱うよう \`formatDateInput\` / \`parseDateInput\` を更新
  - エラーメッセージを「有効な日付を選択してください」に調整
- \`tests/unit/components/OotdEditForm.test.tsx\`:
  - ISO 形式の検証に更新
  - userEvent.type → fireEvent.change に変更（jsdom の type=date 対応）
  - フィクスチャ日付を local-time コンストラクタに統一して TZ ずれを回避

## テスト方法
- \`npm test -- --run\` 全件グリーン (200/200)
- \`npm run typecheck\` / \`npm run lint\` / \`npm run build\` 通過
- ブラウザで /ootd/[id]/edit を開いて日付欄をクリック → カレンダーが出ることを確認

## 影響範囲
- 編集画面のみ。一覧・詳細の表示形式（English-style）は変更なし

## チェックリスト
- [x] コードレビューを依頼した
- [x] テストが完了している
- [ ] ドキュメントを更新した（必要に応じて）
- [x] コミットメッセージが適切である