### PR TITLE
feat: outfit search list screen with keyword search (PR1 of 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ NOTION_KNOWLEDGE_PARENT_PAGE_URL=
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Unsplash API（着こなし検索機能。サーバ側のみ使用）
+UNSPLASH_ACCESS_KEY=

--- a/app/(public)/search/[id]/page.tsx
+++ b/app/(public)/search/[id]/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { ChevronLeftIcon } from "@/components/ui/icons";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+// 詳細画面の本実装は PR3 で行う。PR1 マージ時点での 404 動線を防ぐ目的で
+// プレースホルダを用意し、検索結果一覧へ戻る導線のみ提供する。
+export default async function SnapDetailPlaceholderPage({ params }: PageProps) {
+  await params;
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
+      <div className="flex flex-col items-center justify-center gap-6 text-center">
+        <h1 className="font-display text-3xl tracking-widest text-denim-dark dark:text-offwhite">
+          準備中
+        </h1>
+        <p className="max-w-md text-sm leading-relaxed text-denim/60 dark:text-offwhite/50">
+          このコーデの詳細画面は近日公開予定。
+          <br />
+          AI 解析によるカラー・スタイル分析と類似コーデを表示する機能を PR3
+          で導入する。
+        </p>
+        <Link
+          href="/search"
+          className="inline-flex items-center gap-1.5 rounded-none border border-denim bg-denim px-5 py-2.5 text-sm font-medium tracking-wide text-offwhite transition-colors hover:bg-denim-dark focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:border-denim-light dark:bg-denim-light"
+        >
+          <ChevronLeftIcon width={14} height={14} />
+          検索に戻る
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/(public)/search/page.tsx
+++ b/app/(public)/search/page.tsx
@@ -1,19 +1,5 @@
-import { SearchIcon } from "@/components/ui/icons";
+import { SearchPage } from "@/components/features/search/SearchPage";
 
-export default function SearchPlaceholderPage() {
-  return (
-    <main className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
-      <div className="flex flex-col items-center justify-center gap-4 text-center">
-        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-denim/10 text-denim dark:bg-offwhite/10 dark:text-offwhite">
-          <SearchIcon width={28} height={28} />
-        </div>
-        <h1 className="font-display text-3xl tracking-widest text-denim-dark dark:text-offwhite">
-          着こなし検索
-        </h1>
-        <p className="text-sm text-denim/60 dark:text-offwhite/50 max-w-md">
-          コーデのアイデアを検索する機能は準備中。
-        </p>
-      </div>
-    </main>
-  );
+export default function SearchPageRoute() {
+  return <SearchPage />;
 }

--- a/app/actions/search.ts
+++ b/app/actions/search.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { SnapSearchInputSchema } from "@/types/snap";
+import type { SnapSummary } from "@/types/snap";
+import { findSnapsByQuery, upsertSnaps } from "@/services/snap-service";
+import { searchUnsplashPhotos } from "@/services/unsplash-service";
+
+type ActionResult<T> =
+  | { data: T; error: null }
+  | { data: null; error: { message: string; code: string } };
+
+export async function searchSnapsAction(input: unknown): Promise<
+  ActionResult<{
+    items: SnapSummary[];
+    hasMore: boolean;
+    page: number;
+  }>
+> {
+  const parsed = SnapSearchInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      data: null,
+      error: { message: "Invalid input", code: "VALIDATION_ERROR" },
+    };
+  }
+
+  const { query, page, pageSize } = parsed.data;
+
+  const initialItems = await findSnapsByQuery({ query, page, pageSize });
+
+  if (initialItems.length < pageSize && page === 1) {
+    let items = initialItems;
+    let totalPages = 0;
+    let fetchedFromApi = false;
+
+    try {
+      const { photos, totalPages: tp } = await searchUnsplashPhotos({
+        query,
+        page: 1,
+        perPage: pageSize,
+      });
+      totalPages = tp;
+      await upsertSnaps(photos, query);
+      items = await findSnapsByQuery({ query, page, pageSize });
+      fetchedFromApi = true;
+    } catch {
+      // Unsplash 失敗時は初回取得の items をそのまま使う
+    }
+
+    const hasMore = fetchedFromApi ? totalPages > 1 : items.length === pageSize;
+
+    return {
+      data: { items, hasMore, page },
+      error: null,
+    };
+  }
+
+  const hasMore = initialItems.length === pageSize;
+
+  return {
+    data: { items: initialItems, hasMore, page },
+    error: null,
+  };
+}

--- a/app/actions/search.ts
+++ b/app/actions/search.ts
@@ -28,9 +28,14 @@ export async function searchSnapsAction(input: unknown): Promise<
 
   const initialItems = await findSnapsByQuery({ query, page, pageSize });
 
-  // キャッシュ不足時は要求 page を Unsplash から補完する。page=1 に限定すると
-  // 2ページ目以降が空で打ち止めになるため、全ページで補完を試みる。
-  if (initialItems.length < pageSize) {
+  // キャッシュ不足時は要求 page を Unsplash から補完する。
+  // ただし page>1 で DB に 1 件もキャッシュが無い場合は「末尾を超えた」と
+  // 判断して Unsplash を呼ばない（無駄な API コール・無限ループ防止）。
+  // page=1 で 0 件 のときは Unsplash で初回フェッチが必要なので補完する。
+  const shouldFetchFromApi =
+    initialItems.length < pageSize && (page === 1 || initialItems.length > 0);
+
+  if (shouldFetchFromApi) {
     let items = initialItems;
     let totalPages = 0;
     let fetchedFromApi = false;

--- a/app/actions/search.ts
+++ b/app/actions/search.ts
@@ -28,7 +28,9 @@ export async function searchSnapsAction(input: unknown): Promise<
 
   const initialItems = await findSnapsByQuery({ query, page, pageSize });
 
-  if (initialItems.length < pageSize && page === 1) {
+  // キャッシュ不足時は要求 page を Unsplash から補完する。page=1 に限定すると
+  // 2ページ目以降が空で打ち止めになるため、全ページで補完を試みる。
+  if (initialItems.length < pageSize) {
     let items = initialItems;
     let totalPages = 0;
     let fetchedFromApi = false;
@@ -36,7 +38,7 @@ export async function searchSnapsAction(input: unknown): Promise<
     try {
       const { photos, totalPages: tp } = await searchUnsplashPhotos({
         query,
-        page: 1,
+        page,
         perPage: pageSize,
       });
       totalPages = tp;
@@ -47,7 +49,9 @@ export async function searchSnapsAction(input: unknown): Promise<
       // Unsplash 失敗時は初回取得の items をそのまま使う
     }
 
-    const hasMore = fetchedFromApi ? totalPages > 1 : items.length === pageSize;
+    const hasMore = fetchedFromApi
+      ? totalPages > page
+      : items.length === pageSize;
 
     return {
       data: { items, hasMore, page },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import "./globals.css";
 import { BottomNav } from "@/components/ui/BottomNav";
 import { CalendarIcon, PlusIcon, SearchIcon } from "@/components/ui/icons";
+import { Providers } from "./providers";
 
 const bebasNeue = Bebas_Neue({
   weight: "400",
@@ -32,44 +33,46 @@ export default function RootLayout({
   return (
     <html lang="ja" className={`${bebasNeue.variable} ${notoSansJP.variable}`}>
       <body className="pb-20 md:pb-0">
-        <header className="border-b border-denim/20 bg-denim-dark dark:bg-canvas dark:border-denim-light/20">
-          <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3 sm:px-6">
-            <Link
-              href="/"
-              className="font-display text-2xl tracking-widest text-offwhite hover:text-offwhite/80 transition-colors"
-            >
-              DIG.
-            </Link>
-            <nav
-              aria-label="メインナビゲーション"
-              className="hidden md:flex items-center gap-1"
-            >
+        <Providers>
+          <header className="border-b border-denim/20 bg-denim-dark dark:bg-canvas dark:border-denim-light/20">
+            <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3 sm:px-6">
               <Link
-                href="/ootd"
-                className="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium text-offwhite/70 transition-colors hover:bg-denim hover:text-offwhite focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offwhite/50"
+                href="/"
+                className="font-display text-2xl tracking-widest text-offwhite hover:text-offwhite/80 transition-colors"
               >
-                <CalendarIcon width={14} height={14} />
-                #OOTD
+                DIG.
               </Link>
-              <Link
-                href="/search"
-                className="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium text-offwhite/70 transition-colors hover:bg-denim hover:text-offwhite focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offwhite/50"
+              <nav
+                aria-label="メインナビゲーション"
+                className="hidden md:flex items-center gap-1"
               >
-                <SearchIcon width={14} height={14} />
-                着こなし検索
-              </Link>
-              <Link
-                href="/ootd/new"
-                className="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium text-offwhite/70 transition-colors hover:bg-denim hover:text-offwhite focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offwhite/50"
-              >
-                <PlusIcon width={14} height={14} />
-                追加
-              </Link>
-            </nav>
-          </div>
-        </header>
-        {children}
-        <BottomNav />
+                <Link
+                  href="/ootd"
+                  className="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium text-offwhite/70 transition-colors hover:bg-denim hover:text-offwhite focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offwhite/50"
+                >
+                  <CalendarIcon width={14} height={14} />
+                  #OOTD
+                </Link>
+                <Link
+                  href="/search"
+                  className="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium text-offwhite/70 transition-colors hover:bg-denim hover:text-offwhite focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offwhite/50"
+                >
+                  <SearchIcon width={14} height={14} />
+                  着こなし検索
+                </Link>
+                <Link
+                  href="/ootd/new"
+                  className="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium text-offwhite/70 transition-colors hover:bg-denim hover:text-offwhite focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offwhite/50"
+                >
+                  <PlusIcon width={14} height={14} />
+                  追加
+                </Link>
+              </nav>
+            </div>
+          </header>
+          {children}
+          <BottomNav />
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [client] = useState(
+    () =>
+      new QueryClient({ defaultOptions: { queries: { staleTime: 60_000 } } }),
+  );
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/components/features/search/ConditionsLink.tsx
+++ b/components/features/search/ConditionsLink.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export function ConditionsLink() {
+  return (
+    <Link
+      href="/search/conditions"
+      className="inline-flex items-center gap-1.5 rounded-none border border-denim/30 bg-transparent px-4 py-2 text-sm font-medium tracking-wide text-denim dark:border-denim-light/30 dark:text-denim-light transition-colors hover:border-denim hover:bg-denim/5 dark:hover:border-denim-light dark:hover:bg-denim-light/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2"
+    >
+      こだわり条件を選択
+    </Link>
+  );
+}

--- a/components/features/search/SearchInput.tsx
+++ b/components/features/search/SearchInput.tsx
@@ -31,6 +31,7 @@ export function SearchInput({ onSearch, initialQuery = "" }: SearchInputProps) {
         <input
           type="text"
           role="textbox"
+          aria-label="検索キーワード"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           placeholder="キーワードを入力（例: M-65、デニムジャケット）"

--- a/components/features/search/SearchInput.tsx
+++ b/components/features/search/SearchInput.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { SearchIcon } from "@/components/ui/icons";
+
+interface SearchInputProps {
+  onSearch: (query: string) => void;
+  initialQuery?: string;
+}
+
+export function SearchInput({ onSearch, initialQuery = "" }: SearchInputProps) {
+  const [value, setValue] = useState(initialQuery);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return;
+    onSearch(trimmed);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex items-center gap-2 w-full"
+      role="search"
+    >
+      <div className="relative flex-1">
+        <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-denim/40 dark:text-offwhite/30">
+          <SearchIcon width={16} height={16} />
+        </span>
+        <input
+          type="text"
+          role="textbox"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="キーワードを入力（例: M-65、デニムジャケット）"
+          className="w-full rounded-none border border-denim/20 bg-offwhite dark:bg-canvas-subtle dark:border-denim-light/20 py-2.5 pl-9 pr-4 text-sm text-denim-dark dark:text-offwhite placeholder:text-denim/30 dark:placeholder:text-offwhite/30 focus:border-denim dark:focus:border-denim-light focus:outline-none focus:ring-1 focus:ring-denim dark:focus:ring-denim-light transition-colors"
+        />
+      </div>
+      <button
+        type="submit"
+        aria-label="検索"
+        className="inline-flex items-center gap-1.5 rounded-none border border-denim bg-denim px-4 py-2.5 text-sm font-medium tracking-wide text-offwhite transition-colors hover:bg-denim-dark hover:border-denim-dark focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:border-denim-light dark:bg-denim-light dark:hover:bg-denim whitespace-nowrap"
+      >
+        <SearchIcon width={14} height={14} />
+        検索
+      </button>
+    </form>
+  );
+}

--- a/components/features/search/SearchPage.tsx
+++ b/components/features/search/SearchPage.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { useInfiniteSnapSearch } from "@/hooks/useInfiniteSnapSearch";
+import { SearchInput } from "./SearchInput";
+import { ConditionsLink } from "./ConditionsLink";
+import { SnapGrid } from "./SnapGrid";
+import { ScrollToTopButton } from "@/components/ui/ScrollToTopButton";
+import type { SnapSummary } from "@/types/snap";
+
+export function SearchPage() {
+  const [query, setQuery] = useState("");
+
+  const { data, hasNextPage, isFetchingNextPage, isPending, fetchNextPage } =
+    useInfiniteSnapSearch(query);
+
+  const snaps: SnapSummary[] =
+    data?.pages.flatMap((p) => p.data?.items ?? []) ?? [];
+
+  const hasMore = hasNextPage ?? false;
+  const isLoading =
+    isFetchingNextPage || (isPending && query.trim().length > 0);
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-6 sm:px-6">
+      <div className="mb-4 space-y-3">
+        <SearchInput onSearch={setQuery} initialQuery={query} />
+        <ConditionsLink />
+      </div>
+
+      <SnapGrid
+        snaps={snaps}
+        hasMore={hasMore}
+        isLoading={isLoading}
+        onLoadMore={fetchNextPage}
+      />
+
+      <ScrollToTopButton />
+    </main>
+  );
+}

--- a/components/features/search/SnapCard.tsx
+++ b/components/features/search/SnapCard.tsx
@@ -14,6 +14,7 @@ export function SnapCard({ snap }: SnapCardProps) {
   return (
     <Link
       href={`/search/${snap.id}`}
+      data-testid="snap-card"
       className="block aspect-[3/4] overflow-hidden bg-denim-dark/10 dark:bg-canvas-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2"
     >
       <div className="relative h-full w-full transition-opacity duration-200 hover:opacity-85">

--- a/components/features/search/SnapCard.tsx
+++ b/components/features/search/SnapCard.tsx
@@ -1,0 +1,30 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { SnapSummary } from "@/types/snap";
+
+interface SnapCardProps {
+  snap: SnapSummary;
+}
+
+export function SnapCard({ snap }: SnapCardProps) {
+  const alt = snap.authorName
+    ? `${snap.authorName} のスナップ`
+    : "スナップ画像";
+
+  return (
+    <Link
+      href={`/search/${snap.id}`}
+      className="block aspect-[3/4] overflow-hidden bg-denim-dark/10 dark:bg-canvas-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2"
+    >
+      <div className="relative h-full w-full transition-opacity duration-200 hover:opacity-85">
+        <Image
+          src={snap.imageUrl}
+          alt={alt}
+          fill
+          sizes="(max-width: 768px) 50vw, (max-width: 1280px) 33vw, 25vw"
+          className="object-cover"
+        />
+      </div>
+    </Link>
+  );
+}

--- a/components/features/search/SnapGrid.tsx
+++ b/components/features/search/SnapGrid.tsx
@@ -51,7 +51,7 @@ export function SnapGrid({
   }
 
   return (
-    <div>
+    <div data-testid="snap-grid">
       <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3">
         {snaps.map((snap) => (
           <SnapCard key={snap.id} snap={snap} />

--- a/components/features/search/SnapGrid.tsx
+++ b/components/features/search/SnapGrid.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { SnapSummary } from "@/types/snap";
+import { SnapCard } from "./SnapCard";
+import { Spinner } from "@/components/ui/Spinner";
+
+interface SnapGridProps {
+  snaps: SnapSummary[];
+  hasMore: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
+}
+
+export function SnapGrid({
+  snaps,
+  hasMore,
+  isLoading,
+  onLoadMore,
+}: SnapGridProps) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!hasMore || isLoading) return;
+
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (entry.isIntersecting && hasMore && !isLoading) {
+        onLoadMore();
+      }
+    });
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMore, isLoading, onLoadMore]);
+
+  if (snaps.length === 0 && !isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <p className="text-sm text-denim/50 dark:text-offwhite/40">
+          該当するコーデが見つかりません
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3">
+        {snaps.map((snap) => (
+          <SnapCard key={snap.id} snap={snap} />
+        ))}
+      </div>
+
+      <div ref={sentinelRef} className="h-px w-full" aria-hidden="true" />
+
+      {isLoading && (
+        <div className="flex justify-center py-8">
+          <Spinner size="md" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ui/ScrollToTopButton.tsx
+++ b/components/ui/ScrollToTopButton.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChevronUpIcon } from "@/components/ui/icons";
+
+interface ScrollToTopButtonProps {
+  threshold?: number;
+}
+
+export function ScrollToTopButton({ threshold = 600 }: ScrollToTopButtonProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    function handleScroll() {
+      setVisible(window.scrollY > threshold);
+    }
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [threshold]);
+
+  if (!visible) return null;
+
+  function handleClick() {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="トップへ戻る"
+      className="fixed bottom-24 right-4 z-50 flex h-10 w-10 items-center justify-center rounded-full border border-denim/20 bg-offwhite shadow-md text-denim transition-colors hover:bg-offwhite-subtle hover:shadow-lg dark:bg-canvas-subtle dark:border-denim-light/20 dark:text-offwhite dark:hover:bg-canvas focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2"
+    >
+      <ChevronUpIcon width={18} height={18} />
+    </button>
+  );
+}

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -36,6 +36,14 @@ export function ChevronRightIcon(props: IconProps) {
   );
 }
 
+export function ChevronUpIcon(props: IconProps) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" {...baseProps} {...props}>
+      <polyline points="18 15 12 9 6 15" />
+    </svg>
+  );
+}
+
 export function CloseIcon(props: IconProps) {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" {...baseProps} {...props}>

--- a/hooks/useInfiniteSnapSearch.ts
+++ b/hooks/useInfiniteSnapSearch.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { searchSnapsAction } from "@/app/actions/search";
+
+export function useInfiniteSnapSearch(query: string) {
+  return useInfiniteQuery({
+    queryKey: ["snap-search", query],
+    queryFn: ({ pageParam }) =>
+      searchSnapsAction({ query, page: pageParam, pageSize: 30 }),
+    initialPageParam: 1,
+    getNextPageParam: (last) => {
+      if (last.error || last.data === null) return undefined;
+      if (!last.data.hasMore) return undefined;
+      return last.data.page + 1;
+    },
+    enabled: query.trim().length > 0,
+  });
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,17 +12,24 @@ function resolveSupabaseHost(): string | null {
 
 const supabaseHost = resolveSupabaseHost();
 
+const remotePatterns: NonNullable<NextConfig["images"]>["remotePatterns"] = [
+  {
+    protocol: "https",
+    hostname: "images.unsplash.com",
+  },
+];
+
+if (supabaseHost) {
+  remotePatterns.push({
+    protocol: "https",
+    hostname: supabaseHost,
+    pathname: "/storage/v1/object/public/**",
+  });
+}
+
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: supabaseHost
-      ? [
-          {
-            protocol: "https",
-            hostname: supabaseHost,
-            pathname: "/storage/v1/object/public/**",
-          },
-        ]
-      : [],
+    remotePatterns,
   },
 };
 

--- a/prisma/migrations/20260510_add_snap/migration.sql
+++ b/prisma/migrations/20260510_add_snap/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "Snap" (
+    "id" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "imageUrl" TEXT NOT NULL,
+    "sourceUrl" TEXT NOT NULL,
+    "authorName" TEXT,
+    "authorUrl" TEXT,
+    "title" TEXT,
+    "description" TEXT,
+    "tags" TEXT[],
+    "searchQuery" TEXT NOT NULL,
+    "oneLiner" TEXT,
+    "colorPalette" JSONB,
+    "styles" JSONB,
+    "aiDescription" TEXT,
+    "detectedItems" JSONB,
+    "radarScores" JSONB,
+    "analyzedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Snap_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Snap_searchQuery_idx" ON "Snap"("searchQuery");
+
+-- CreateIndex
+CREATE INDEX "Snap_createdAt_idx" ON "Snap"("createdAt");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "Snap_source_externalId_key" ON "Snap"("source", "externalId");

--- a/prisma/migrations/20260510_add_snap/migration.sql
+++ b/prisma/migrations/20260510_add_snap/migration.sql
@@ -10,7 +10,7 @@ CREATE TABLE "Snap" (
     "title" TEXT,
     "description" TEXT,
     "tags" TEXT[],
-    "searchQuery" TEXT NOT NULL,
+    "searchQueries" TEXT[],
     "oneLiner" TEXT,
     "colorPalette" JSONB,
     "styles" JSONB,
@@ -25,7 +25,7 @@ CREATE TABLE "Snap" (
 );
 
 -- CreateIndex
-CREATE INDEX "Snap_searchQuery_idx" ON "Snap"("searchQuery");
+CREATE INDEX "Snap_searchQueries_idx" ON "Snap" USING GIN ("searchQueries");
 
 -- CreateIndex
 CREATE INDEX "Snap_createdAt_idx" ON "Snap"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,7 +35,7 @@ model Snap {
   title         String?
   description   String?
   tags          String[]
-  searchQuery   String
+  searchQueries String[]
   oneLiner      String?
   colorPalette  Json?
   styles        Json?
@@ -47,6 +47,6 @@ model Snap {
   updatedAt     DateTime  @updatedAt
 
   @@unique([source, externalId])
-  @@index([searchQuery])
+  @@index([searchQueries], type: Gin)
   @@index([createdAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,3 +23,30 @@ model Ootd {
 
   @@index([date])
 }
+
+model Snap {
+  id            String    @id @default(uuid())
+  source        String
+  externalId    String
+  imageUrl      String
+  sourceUrl     String
+  authorName    String?
+  authorUrl     String?
+  title         String?
+  description   String?
+  tags          String[]
+  searchQuery   String
+  oneLiner      String?
+  colorPalette  Json?
+  styles        Json?
+  aiDescription String?
+  detectedItems Json?
+  radarScores   Json?
+  analyzedAt    DateTime?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@unique([source, externalId])
+  @@index([searchQuery])
+  @@index([createdAt])
+}

--- a/services/snap-service.ts
+++ b/services/snap-service.ts
@@ -48,7 +48,10 @@ export async function upsertSnaps(
           tags: photo.tags?.map((t) => t.title) ?? [],
           searchQuery: query,
         },
-        update: {},
+        // 既存レコードが別キーワードで再ヒットした場合、searchQuery を最新クエリで
+        // 上書きすることで `findSnapsByQuery({ where: { searchQuery: query } })`
+        // から欠落するのを防ぐ。多対多の履歴管理は PR2 以降で別テーブル化する。
+        update: { searchQuery: query },
       }),
     ),
   );

--- a/services/snap-service.ts
+++ b/services/snap-service.ts
@@ -1,0 +1,55 @@
+import { prisma } from "@/lib/prisma";
+import type { SnapSummary } from "@/types/snap";
+import type { UnsplashPhoto } from "@/services/unsplash-service";
+
+export async function findSnapsByQuery(params: {
+  query: string;
+  page: number;
+  pageSize: number;
+}): Promise<SnapSummary[]> {
+  const { query, page, pageSize } = params;
+  const records = await prisma.snap.findMany({
+    where: { searchQuery: query },
+    orderBy: { createdAt: "desc" },
+    skip: (page - 1) * pageSize,
+    take: pageSize,
+    select: {
+      id: true,
+      imageUrl: true,
+      authorName: true,
+      sourceUrl: true,
+    },
+  });
+  return records;
+}
+
+export async function upsertSnaps(
+  photos: UnsplashPhoto[],
+  query: string,
+): Promise<void> {
+  await Promise.all(
+    photos.map((photo) =>
+      prisma.snap.upsert({
+        where: {
+          source_externalId: {
+            source: "unsplash",
+            externalId: photo.id,
+          },
+        },
+        create: {
+          source: "unsplash",
+          externalId: photo.id,
+          imageUrl: photo.urls.regular,
+          sourceUrl: photo.links.html,
+          authorName: photo.user.name,
+          authorUrl: photo.user.links.html,
+          title: null,
+          description: photo.alt_description ?? photo.description,
+          tags: photo.tags?.map((t) => t.title) ?? [],
+          searchQuery: query,
+        },
+        update: {},
+      }),
+    ),
+  );
+}

--- a/services/snap-service.ts
+++ b/services/snap-service.ts
@@ -9,7 +9,7 @@ export async function findSnapsByQuery(params: {
 }): Promise<SnapSummary[]> {
   const { query, page, pageSize } = params;
   const records = await prisma.snap.findMany({
-    where: { searchQuery: query },
+    where: { searchQueries: { has: query } },
     orderBy: { createdAt: "desc" },
     skip: (page - 1) * pageSize,
     take: pageSize,
@@ -23,36 +23,72 @@ export async function findSnapsByQuery(params: {
   return records;
 }
 
+/**
+ * Unsplash から取得した写真群を Snap テーブルにキャッシュする。
+ *
+ * - 新規写真: `createMany({ skipDuplicates: true })` で 1 クエリにバルク INSERT
+ *   （N 件並列 upsert を発行していた旧実装の DB コネクション枯渇リスクを解消）
+ * - 既存写真: `searchQueries` に `query` が未登録のものだけ `update` で push
+ *   （同一画像が別キーワードでヒットした履歴を保持し、過去キーワードからの
+ *   再検索でも引き続き返るようにする）
+ *
+ * 競合: 別リクエストが同時に同 externalId を upsert する可能性は低いが、
+ * `createMany.skipDuplicates` で重複は黙殺、`update.searchQueries.push` は
+ * Prisma 内部で配列追記される。完全な原子性が必要になったら $transaction
+ * （Interactive）に切り替える。
+ */
 export async function upsertSnaps(
   photos: UnsplashPhoto[],
   query: string,
 ): Promise<void> {
-  await Promise.all(
-    photos.map((photo) =>
-      prisma.snap.upsert({
-        where: {
-          source_externalId: {
-            source: "unsplash",
-            externalId: photo.id,
-          },
-        },
-        create: {
-          source: "unsplash",
-          externalId: photo.id,
-          imageUrl: photo.urls.regular,
-          sourceUrl: photo.links.html,
-          authorName: photo.user.name,
-          authorUrl: photo.user.links.html,
-          title: null,
-          description: photo.alt_description ?? photo.description,
-          tags: photo.tags?.map((t) => t.title) ?? [],
-          searchQuery: query,
-        },
-        // 既存レコードが別キーワードで再ヒットした場合、searchQuery を最新クエリで
-        // 上書きすることで `findSnapsByQuery({ where: { searchQuery: query } })`
-        // から欠落するのを防ぐ。多対多の履歴管理は PR2 以降で別テーブル化する。
-        update: { searchQuery: query },
-      }),
-    ),
+  if (photos.length === 0) return;
+
+  const externalIds = photos.map((p) => p.id);
+  const existing = await prisma.snap.findMany({
+    where: {
+      source: "unsplash",
+      externalId: { in: externalIds },
+    },
+    select: { externalId: true, searchQueries: true },
+  });
+  const existingMap = new Map(
+    existing.map((e) => [e.externalId, e.searchQueries]),
   );
+
+  const toCreate = photos.filter((p) => !existingMap.has(p.id));
+  const toAppend = photos.filter((p) => {
+    const queries = existingMap.get(p.id);
+    return queries !== undefined && !queries.includes(query);
+  });
+
+  if (toCreate.length > 0) {
+    await prisma.snap.createMany({
+      data: toCreate.map((photo) => ({
+        source: "unsplash",
+        externalId: photo.id,
+        imageUrl: photo.urls.regular,
+        sourceUrl: photo.links.html,
+        authorName: photo.user.name,
+        authorUrl: photo.user.links.html,
+        title: null,
+        description: photo.alt_description ?? photo.description,
+        tags: photo.tags?.map((t) => t.title) ?? [],
+        searchQueries: [query],
+      })),
+      skipDuplicates: true,
+    });
+  }
+
+  if (toAppend.length > 0) {
+    await Promise.all(
+      toAppend.map((photo) =>
+        prisma.snap.update({
+          where: {
+            source_externalId: { source: "unsplash", externalId: photo.id },
+          },
+          data: { searchQueries: { push: query } },
+        }),
+      ),
+    );
+  }
 }

--- a/services/unsplash-service.ts
+++ b/services/unsplash-service.ts
@@ -34,6 +34,7 @@ export async function searchUnsplashPhotos(params: {
   const url = `https://api.unsplash.com/search/photos?${searchParams.toString()}`;
 
   const response = await fetch(url, {
+    signal: AbortSignal.timeout(8000),
     headers: {
       Authorization: `Client-ID ${accessKey}`,
     },

--- a/services/unsplash-service.ts
+++ b/services/unsplash-service.ts
@@ -1,0 +1,54 @@
+export interface UnsplashPhoto {
+  id: string;
+  urls: { regular: string; small: string };
+  description: string | null;
+  alt_description: string | null;
+  user: { name: string; links: { html: string } };
+  links: { html: string };
+  tags?: { title: string }[];
+}
+
+interface UnsplashApiResponse {
+  total: number;
+  total_pages: number;
+  results: UnsplashPhoto[];
+}
+
+export async function searchUnsplashPhotos(params: {
+  query: string;
+  page: number;
+  perPage: number;
+}): Promise<{ photos: UnsplashPhoto[]; totalPages: number }> {
+  const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+  if (!accessKey) {
+    throw new Error("UNSPLASH_ACCESS_KEY is not set");
+  }
+
+  const enhancedQuery = `${params.query} outfit fashion`;
+  const searchParams = new URLSearchParams({
+    query: enhancedQuery,
+    page: String(params.page),
+    per_page: String(params.perPage),
+  });
+
+  const url = `https://api.unsplash.com/search/photos?${searchParams.toString()}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Client-ID ${accessKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Unsplash API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as UnsplashApiResponse;
+
+  return {
+    photos: data.results,
+    totalPages: data.total_pages,
+  };
+}

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * 着こなし検索機能 E2E テストスイート（PR1）
+ *
+ * 対象フロー:
+ *   /search 訪問 → 検索フィールド入力 → 検索ボタン → 結果カード表示
+ *   → 無限スクロールで追加ロード → TOPまで戻るボタン
+ *   → こだわり条件画面へのリンク
+ *
+ * 注意: 外部 API（Unsplash）と DB は実環境依存のため、UI 層のレンダリング
+ *   と動線検証のみを対象とする。検索実行で結果が 0 件のケースでも UI が
+ *   壊れないことを確認する。
+ */
+
+test.describe("Phase 0: 事前確認", () => {
+  test("/search が 200 で表示される", async ({ page }) => {
+    await page.goto("/search");
+    await expect(page).toHaveTitle(/DIG/);
+  });
+
+  test("コンソールに JS エラーが存在しない", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        if (!msg.text().includes("favicon.ico")) {
+          errors.push(msg.text());
+        }
+      }
+    });
+    await page.goto("/search");
+    await page.waitForLoadState("networkidle");
+    expect(errors).toHaveLength(0);
+  });
+});
+
+test.describe("Phase 1: 検索結果一覧画面の基本UI", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/search");
+  });
+
+  test("検索入力フィールドと検索ボタンが表示される", async ({ page }) => {
+    await expect(page.getByRole("textbox")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /検索/ }).first(),
+    ).toBeVisible();
+  });
+
+  test("「こだわり条件を選択」ボタン（リンク）が表示される", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole("link", { name: /こだわり条件を選択/ }),
+    ).toBeVisible();
+  });
+
+  test("「こだわり条件を選択」リンクが /search/conditions を指す", async ({
+    page,
+  }) => {
+    const link = page.getByRole("link", { name: /こだわり条件を選択/ });
+    await expect(link).toHaveAttribute("href", "/search/conditions");
+  });
+});
+
+test.describe("Phase 2: キーワード検索フロー", () => {
+  test("テキストを入力して検索ボタンを押すと検索が発火する", async ({
+    page,
+  }) => {
+    await page.goto("/search");
+    const input = page.getByRole("textbox");
+    await input.fill("M-65");
+    await page.getByRole("button", { name: /検索/ }).first().click();
+
+    // 検索後、ローディング状態 or 結果 or 空状態のいずれかが表示される
+    // （外部APIに依存するため厳密な結果数は検証しない）
+    await page.waitForLoadState("networkidle");
+    const hasContent =
+      (await page.getByRole("link").count()) > 0 ||
+      (await page
+        .getByText(/該当|見つかり/)
+        .isVisible()
+        .catch(() => false));
+    expect(hasContent).toBe(true);
+  });
+
+  test("空文字検索ではエラーで落ちずページが維持される", async ({ page }) => {
+    await page.goto("/search");
+    await page.getByRole("button", { name: /検索/ }).first().click();
+    await expect(page.getByRole("textbox")).toBeVisible();
+  });
+});
+
+test.describe("Phase 3: TOPまで戻るボタン", () => {
+  test("初期表示時は TOP ボタンが非表示", async ({ page }) => {
+    await page.goto("/search");
+    const topBtn = page.getByRole("button", { name: /トップ|TOP|top/i });
+    await expect(topBtn).not.toBeVisible();
+  });
+
+  test("600px 以上スクロールするとTOPボタンが表示される", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/search");
+    // 検証用にスクロール対象を生成（結果が無くてもページ全体スクロールできるよう本文を伸ばす）
+    await page.evaluate(() => window.scrollTo(0, 800));
+    const topBtn = page.getByRole("button", { name: /トップ|TOP|top/i });
+    // 結果が無くてもボタンが出る設計を確認
+    await topBtn.waitFor({ state: "visible", timeout: 3000 }).catch(() => {});
+    // ボタンが存在する場合のみ動作確認
+    if (await topBtn.isVisible().catch(() => false)) {
+      await topBtn.click();
+      const scrollY = await page.evaluate(() => window.scrollY);
+      expect(scrollY).toBe(0);
+    }
+  });
+});
+
+test.describe("Phase 4: ナビゲーション・共通UX", () => {
+  test("PC版ヘッダーの「着こなし検索」リンクから /search へ遷移できる", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/");
+    const nav = page.getByRole("navigation", { name: "メインナビゲーション" });
+    await nav.getByRole("link", { name: /着こなし検索/ }).click();
+    await expect(page).toHaveURL("/search");
+  });
+
+  test("SP版ボトムナビ「着こなし検索」から /search へ遷移できる", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+    const bottomNav = page.getByRole("navigation", {
+      name: "ボトムナビゲーション",
+    });
+    await bottomNav.getByRole("link", { name: "着こなし検索" }).click();
+    await expect(page).toHaveURL("/search");
+  });
+
+  test("DIG. ロゴから / へ戻れる", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/search");
+    await page.getByRole("link", { name: "DIG." }).click();
+    await expect(page).toHaveURL("/");
+  });
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -71,16 +71,20 @@ test.describe("Phase 2: キーワード検索フロー", () => {
     await input.fill("M-65");
     await page.getByRole("button", { name: /検索/ }).first().click();
 
-    // 検索後、ローディング状態 or 結果 or 空状態のいずれかが表示される
-    // （外部APIに依存するため厳密な結果数は検証しない）
+    // 検索後、結果領域（snap-grid）にカードが出るか、空状態メッセージが出る
+    // 常設リンク（ナビ等）を拾って偽陽性にならないよう testid で結果領域に限定する。
     await page.waitForLoadState("networkidle");
-    const hasContent =
-      (await page.getByRole("link").count()) > 0 ||
-      (await page
-        .getByText(/該当|見つかり/)
-        .isVisible()
-        .catch(() => false));
-    expect(hasContent).toBe(true);
+    const resultArea = page.getByTestId("snap-grid");
+    const hasResultCards =
+      (await resultArea
+        .getByTestId("snap-card")
+        .count()
+        .catch(() => 0)) > 0;
+    const hasEmptyState = await page
+      .getByText(/該当|見つかり/)
+      .isVisible()
+      .catch(() => false);
+    expect(hasResultCards || hasEmptyState).toBe(true);
   });
 
   test("空文字検索ではエラーで落ちずページが維持される", async ({ page }) => {
@@ -103,14 +107,12 @@ test.describe("Phase 3: TOPまで戻るボタン", () => {
     // 検証用にスクロール対象を生成（結果が無くてもページ全体スクロールできるよう本文を伸ばす）
     await page.evaluate(() => window.scrollTo(0, 800));
     const topBtn = page.getByRole("button", { name: /トップ|TOP|top/i });
-    // 結果が無くてもボタンが出る設計を確認
-    await topBtn.waitFor({ state: "visible", timeout: 3000 }).catch(() => {});
-    // ボタンが存在する場合のみ動作確認
-    if (await topBtn.isVisible().catch(() => false)) {
-      await topBtn.click();
-      const scrollY = await page.evaluate(() => window.scrollY);
-      expect(scrollY).toBe(0);
-    }
+    // 仕様「600px 以上で表示」を必須アサート化（条件付きスキップで偽陽性にしない）
+    await expect(topBtn).toBeVisible({ timeout: 3000 });
+    await topBtn.click();
+    await expect
+      .poll(async () => page.evaluate(() => window.scrollY))
+      .toBeLessThanOrEqual(5);
   });
 });
 

--- a/tests/unit/actions/search.test.ts
+++ b/tests/unit/actions/search.test.ts
@@ -1,0 +1,288 @@
+// ---------------------------------------------------------------------------
+// searchSnapsAction のユニットテスト
+//
+// snap-service / unsplash-service を vi.mock して Server Action の振る舞いを検証する。
+// - Zod バリデーション（不正 input → ActionResult error）
+// - キャッシュヒット（pageSize 件以上 → Unsplash を呼ばない）
+// - キャッシュミス + page=1 → Unsplash 呼び出し → upsert → 再取得
+// - Unsplash エラー時のフォールバック（DB の現状をそのまま返す）
+// ---------------------------------------------------------------------------
+
+const findSnapsByQueryMock = vi.fn();
+const upsertSnapsMock = vi.fn();
+const searchUnsplashPhotosMock = vi.fn();
+
+vi.mock("@/services/snap-service", () => ({
+  findSnapsByQuery: (...args: unknown[]) => findSnapsByQueryMock(...args),
+  upsertSnaps: (...args: unknown[]) => upsertSnapsMock(...args),
+}));
+
+vi.mock("@/services/unsplash-service", () => ({
+  searchUnsplashPhotos: (...args: unknown[]) =>
+    searchUnsplashPhotosMock(...args),
+}));
+
+import { searchSnapsAction } from "@/app/actions/search";
+import type { UnsplashPhoto } from "@/services/unsplash-service";
+
+// ---------------------------------------------------------------------------
+// フィクスチャ
+// ---------------------------------------------------------------------------
+const makeSnapSummary = (id: string) => ({
+  id,
+  imageUrl: `https://images.unsplash.com/${id}/regular`,
+  authorName: "Test Author",
+  sourceUrl: `https://unsplash.com/photos/${id}`,
+});
+
+const makeUnsplashPhoto = (id: string): UnsplashPhoto => ({
+  id,
+  urls: {
+    regular: `https://images.unsplash.com/${id}/regular`,
+    small: `https://images.unsplash.com/${id}/small`,
+  },
+  description: "A stylish outfit",
+  alt_description: "Person in stylish outfit",
+  user: {
+    name: "Test Author",
+    links: { html: `https://unsplash.com/@testauthor` },
+  },
+  links: { html: `https://unsplash.com/photos/${id}` },
+  tags: [{ title: "fashion" }],
+});
+
+const VALID_INPUT = { query: "denim jacket", page: 1, pageSize: 30 };
+
+// ---------------------------------------------------------------------------
+// セットアップ
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Zod バリデーション
+// ---------------------------------------------------------------------------
+describe("searchSnapsAction — 入力バリデーション", () => {
+  it("query が未指定のとき VALIDATION_ERROR を返す", async () => {
+    const result = await searchSnapsAction({});
+
+    expect(result).toMatchObject({
+      data: null,
+      error: { code: "VALIDATION_ERROR" },
+    });
+    expect(findSnapsByQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("query が空文字のとき VALIDATION_ERROR を返す", async () => {
+    const result = await searchSnapsAction({ query: "" });
+
+    expect(result).toMatchObject({
+      data: null,
+      error: { code: "VALIDATION_ERROR" },
+    });
+  });
+
+  it("query が 201 文字以上のとき VALIDATION_ERROR を返す", async () => {
+    const result = await searchSnapsAction({ query: "a".repeat(201) });
+
+    expect(result).toMatchObject({
+      data: null,
+      error: { code: "VALIDATION_ERROR" },
+    });
+  });
+
+  it("query が 200 文字ちょうどのとき VALIDATION_ERROR にならない（境界値）", async () => {
+    findSnapsByQueryMock.mockResolvedValue([]);
+    searchUnsplashPhotosMock.mockResolvedValue({ photos: [], totalPages: 0 });
+    upsertSnapsMock.mockResolvedValue(undefined);
+
+    const result = await searchSnapsAction({ query: "a".repeat(200) });
+
+    expect(result).not.toMatchObject({
+      data: null,
+      error: { code: "VALIDATION_ERROR" },
+    });
+  });
+
+  it("page が 0 のとき VALIDATION_ERROR を返す", async () => {
+    const result = await searchSnapsAction({ query: "jacket", page: 0 });
+
+    expect(result).toMatchObject({
+      data: null,
+      error: { code: "VALIDATION_ERROR" },
+    });
+  });
+
+  it("pageSize が 51 のとき VALIDATION_ERROR を返す（上限 50）", async () => {
+    const result = await searchSnapsAction({
+      query: "jacket",
+      page: 1,
+      pageSize: 51,
+    });
+
+    expect(result).toMatchObject({
+      data: null,
+      error: { code: "VALIDATION_ERROR" },
+    });
+  });
+
+  it("input が null のとき VALIDATION_ERROR を返す", async () => {
+    const result = await searchSnapsAction(null);
+
+    expect(result).toMatchObject({
+      data: null,
+      error: { code: "VALIDATION_ERROR" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// キャッシュヒット（Unsplash を呼ばない）
+// ---------------------------------------------------------------------------
+describe("searchSnapsAction — キャッシュ十分（Unsplash 非呼び出し）", () => {
+  it("DB が pageSize 件以上返したとき Unsplash を呼ばない", async () => {
+    const snaps = Array.from({ length: 30 }, (_, i) =>
+      makeSnapSummary(`snap-${i}`),
+    );
+    findSnapsByQueryMock.mockResolvedValue(snaps);
+
+    await searchSnapsAction(VALID_INPUT);
+
+    expect(searchUnsplashPhotosMock).not.toHaveBeenCalled();
+    expect(upsertSnapsMock).not.toHaveBeenCalled();
+  });
+
+  it("キャッシュヒット時に items と hasMore を含む data を返す", async () => {
+    const snaps = Array.from({ length: 30 }, (_, i) =>
+      makeSnapSummary(`snap-${i}`),
+    );
+    findSnapsByQueryMock.mockResolvedValue(snaps);
+
+    const result = await searchSnapsAction(VALID_INPUT);
+
+    expect(result).toMatchObject({
+      data: expect.objectContaining({
+        items: expect.any(Array),
+        hasMore: expect.any(Boolean),
+        page: 1,
+      }),
+      error: null,
+    });
+  });
+
+  it("page=2 のとき（DB 件数に関わらず）Unsplash を呼ばない", async () => {
+    // page=2 以降はキャッシュ補充を試みない仕様
+    findSnapsByQueryMock.mockResolvedValue([makeSnapSummary("snap-1")]);
+
+    await searchSnapsAction({ ...VALID_INPUT, page: 2 });
+
+    expect(searchUnsplashPhotosMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// キャッシュミス（Unsplash 呼び出し + upsert + 再取得）
+// ---------------------------------------------------------------------------
+describe("searchSnapsAction — キャッシュ不足 + page=1（Unsplash 呼び出し）", () => {
+  it("DB が pageSize 未満のとき Unsplash を呼ぶ", async () => {
+    // 最初の findSnapsByQuery（upsert 前）は 0 件
+    findSnapsByQueryMock.mockResolvedValueOnce([]);
+    const photos = Array.from({ length: 10 }, (_, i) =>
+      makeUnsplashPhoto(`photo-${i}`),
+    );
+    searchUnsplashPhotosMock.mockResolvedValue({
+      photos,
+      totalPages: 1,
+    });
+    upsertSnapsMock.mockResolvedValue(undefined);
+    // upsert 後の再取得
+    findSnapsByQueryMock.mockResolvedValueOnce(
+      photos.map((p) => makeSnapSummary(p.id)),
+    );
+
+    await searchSnapsAction({ ...VALID_INPUT, page: 1 });
+
+    expect(searchUnsplashPhotosMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("Unsplash 呼び出し後に upsertSnaps を実行する", async () => {
+    findSnapsByQueryMock.mockResolvedValueOnce([]);
+    const photos = [makeUnsplashPhoto("photo-x")];
+    searchUnsplashPhotosMock.mockResolvedValue({ photos, totalPages: 1 });
+    upsertSnapsMock.mockResolvedValue(undefined);
+    findSnapsByQueryMock.mockResolvedValueOnce([makeSnapSummary("photo-x")]);
+
+    await searchSnapsAction({ query: "M-65", page: 1, pageSize: 30 });
+
+    expect(upsertSnapsMock).toHaveBeenCalledWith(photos, "M-65");
+  });
+
+  it("upsert 後に再度 DB から取得して items を返す", async () => {
+    findSnapsByQueryMock.mockResolvedValueOnce([]);
+    searchUnsplashPhotosMock.mockResolvedValue({
+      photos: [makeUnsplashPhoto("photo-y")],
+      totalPages: 1,
+    });
+    upsertSnapsMock.mockResolvedValue(undefined);
+    const refreshedSnaps = [makeSnapSummary("photo-y")];
+    findSnapsByQueryMock.mockResolvedValueOnce(refreshedSnaps);
+
+    const result = await searchSnapsAction(VALID_INPUT);
+
+    expect(result).toMatchObject({
+      data: { items: refreshedSnaps },
+      error: null,
+    });
+    // findSnapsByQuery が 2 回呼ばれる（キャッシュ確認 + 再取得）
+    expect(findSnapsByQueryMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unsplash エラー時のフォールバック
+// ---------------------------------------------------------------------------
+describe("searchSnapsAction — Unsplash エラーのフォールバック", () => {
+  it("Unsplash がエラーを投げても data を返す（エラーで失敗させない）", async () => {
+    findSnapsByQueryMock.mockResolvedValue([makeSnapSummary("cached-snap")]);
+    // DB が 1 件しかない（pageSize=30 未満）かつ page=1 → Unsplash を試みる
+    findSnapsByQueryMock.mockResolvedValueOnce([
+      makeSnapSummary("cached-snap"),
+    ]);
+    searchUnsplashPhotosMock.mockRejectedValue(new Error("Network error"));
+
+    const result = await searchSnapsAction(VALID_INPUT);
+
+    // error フィールドが null でデータが返る
+    expect(result).not.toMatchObject({ data: null });
+    expect(result).toMatchObject({ error: null });
+  });
+
+  it("Unsplash エラー時は DB の現状の items をそのまま返す", async () => {
+    const cachedSnap = makeSnapSummary("cached-snap-1");
+    findSnapsByQueryMock.mockResolvedValueOnce([cachedSnap]);
+    searchUnsplashPhotosMock.mockRejectedValue(
+      new Error("Rate limit exceeded"),
+    );
+
+    const result = await searchSnapsAction(VALID_INPUT);
+
+    if ("data" in result && result.data !== null) {
+      expect(result.data.items).toContainEqual(cachedSnap);
+    } else {
+      // data が null なら失敗とみなす（フォールバック仕様違反）
+      expect(result.data).not.toBeNull();
+    }
+  });
+
+  it("Unsplash エラー時は upsertSnaps を呼ばない", async () => {
+    findSnapsByQueryMock.mockResolvedValueOnce([]);
+    searchUnsplashPhotosMock.mockRejectedValue(
+      new Error("503 Service Unavailable"),
+    );
+
+    await searchSnapsAction(VALID_INPUT);
+
+    expect(upsertSnapsMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/actions/search.test.ts
+++ b/tests/unit/actions/search.test.ts
@@ -114,14 +114,31 @@ describe("searchSnapsAction — 入力バリデーション", () => {
     });
   });
 
-  it("pageSize が 51 のとき VALIDATION_ERROR を返す（上限 50）", async () => {
+  it("pageSize が 31 のとき VALIDATION_ERROR を返す（Unsplash per_page 上限 30 に合わせる）", async () => {
     const result = await searchSnapsAction({
       query: "jacket",
       page: 1,
-      pageSize: 51,
+      pageSize: 31,
     });
 
     expect(result).toMatchObject({
+      data: null,
+      error: { code: "VALIDATION_ERROR" },
+    });
+  });
+
+  it("pageSize が 30 のとき VALIDATION_ERROR にならない（境界値）", async () => {
+    findSnapsByQueryMock.mockResolvedValue(
+      Array.from({ length: 30 }, (_, i) => makeSnapSummary(`snap-${i}`)),
+    );
+
+    const result = await searchSnapsAction({
+      query: "jacket",
+      page: 1,
+      pageSize: 30,
+    });
+
+    expect(result).not.toMatchObject({
       data: null,
       error: { code: "VALIDATION_ERROR" },
     });
@@ -171,9 +188,11 @@ describe("searchSnapsAction — キャッシュ十分（Unsplash 非呼び出し
     });
   });
 
-  it("page=2 のとき（DB 件数に関わらず）Unsplash を呼ばない", async () => {
-    // page=2 以降はキャッシュ補充を試みない仕様
-    findSnapsByQueryMock.mockResolvedValue([makeSnapSummary("snap-1")]);
+  it("page=2 で DB が pageSize 件以上返したとき Unsplash を呼ばない", async () => {
+    const snaps = Array.from({ length: 30 }, (_, i) =>
+      makeSnapSummary(`snap-${i}`),
+    );
+    findSnapsByQueryMock.mockResolvedValue(snaps);
 
     await searchSnapsAction({ ...VALID_INPUT, page: 2 });
 
@@ -184,7 +203,7 @@ describe("searchSnapsAction — キャッシュ十分（Unsplash 非呼び出し
 // ---------------------------------------------------------------------------
 // キャッシュミス（Unsplash 呼び出し + upsert + 再取得）
 // ---------------------------------------------------------------------------
-describe("searchSnapsAction — キャッシュ不足 + page=1（Unsplash 呼び出し）", () => {
+describe("searchSnapsAction — キャッシュ不足（Unsplash 呼び出し）", () => {
   it("DB が pageSize 未満のとき Unsplash を呼ぶ", async () => {
     // 最初の findSnapsByQuery（upsert 前）は 0 件
     findSnapsByQueryMock.mockResolvedValueOnce([]);
@@ -216,6 +235,67 @@ describe("searchSnapsAction — キャッシュ不足 + page=1（Unsplash 呼び
     await searchSnapsAction({ query: "M-65", page: 1, pageSize: 30 });
 
     expect(upsertSnapsMock).toHaveBeenCalledWith(photos, "M-65");
+  });
+
+  it("page=2 で DB が pageSize 未満のとき Unsplash を page=2 で呼ぶ（無限スクロール継続）", async () => {
+    findSnapsByQueryMock.mockResolvedValueOnce([
+      makeSnapSummary("snap-cached"),
+    ]);
+    searchUnsplashPhotosMock.mockResolvedValue({
+      photos: [makeUnsplashPhoto("photo-p2")],
+      totalPages: 5,
+    });
+    upsertSnapsMock.mockResolvedValue(undefined);
+    findSnapsByQueryMock.mockResolvedValueOnce([
+      makeSnapSummary("snap-cached"),
+      makeSnapSummary("photo-p2"),
+    ]);
+
+    await searchSnapsAction({ query: "M-65", page: 2, pageSize: 30 });
+
+    expect(searchUnsplashPhotosMock).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2, perPage: 30 }),
+    );
+  });
+
+  it("hasMore は totalPages > page で計算される", async () => {
+    findSnapsByQueryMock.mockResolvedValueOnce([]);
+    searchUnsplashPhotosMock.mockResolvedValue({
+      photos: [makeUnsplashPhoto("photo-1")],
+      totalPages: 3,
+    });
+    upsertSnapsMock.mockResolvedValue(undefined);
+    findSnapsByQueryMock.mockResolvedValueOnce([makeSnapSummary("photo-1")]);
+
+    const result = await searchSnapsAction({
+      query: "M-65",
+      page: 2,
+      pageSize: 30,
+    });
+
+    expect(result).toMatchObject({
+      data: { hasMore: true, page: 2 },
+    });
+  });
+
+  it("totalPages === page のとき hasMore は false", async () => {
+    findSnapsByQueryMock.mockResolvedValueOnce([]);
+    searchUnsplashPhotosMock.mockResolvedValue({
+      photos: [makeUnsplashPhoto("photo-1")],
+      totalPages: 2,
+    });
+    upsertSnapsMock.mockResolvedValue(undefined);
+    findSnapsByQueryMock.mockResolvedValueOnce([makeSnapSummary("photo-1")]);
+
+    const result = await searchSnapsAction({
+      query: "M-65",
+      page: 2,
+      pageSize: 30,
+    });
+
+    expect(result).toMatchObject({
+      data: { hasMore: false },
+    });
   });
 
   it("upsert 後に再度 DB から取得して items を返す", async () => {

--- a/tests/unit/actions/search.test.ts
+++ b/tests/unit/actions/search.test.ts
@@ -57,7 +57,9 @@ const VALID_INPUT = { query: "denim jacket", page: 1, pageSize: 30 };
 // セットアップ
 // ---------------------------------------------------------------------------
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks は mockResolvedValueOnce のキューも全クリアする。
+  // clearAllMocks だと未消費のキューが次のテストにリークするので使わない。
+  vi.resetAllMocks();
 });
 
 // ---------------------------------------------------------------------------
@@ -188,6 +190,18 @@ describe("searchSnapsAction — キャッシュ十分（Unsplash 非呼び出し
     });
   });
 
+  it("page=2 で DB が 0 件のとき Unsplash を呼ばない（末尾と判断・無限ループ防止）", async () => {
+    findSnapsByQueryMock.mockResolvedValue([]);
+
+    const result = await searchSnapsAction({ ...VALID_INPUT, page: 2 });
+
+    expect(searchUnsplashPhotosMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      data: { items: [], hasMore: false, page: 2 },
+      error: null,
+    });
+  });
+
   it("page=2 で DB が pageSize 件以上返したとき Unsplash を呼ばない", async () => {
     const snaps = Array.from({ length: 30 }, (_, i) =>
       makeSnapSummary(`snap-${i}`),
@@ -258,14 +272,20 @@ describe("searchSnapsAction — キャッシュ不足（Unsplash 呼び出し）
     );
   });
 
-  it("hasMore は totalPages > page で計算される", async () => {
-    findSnapsByQueryMock.mockResolvedValueOnce([]);
+  it("hasMore は totalPages > page で計算される（page=2 で部分キャッシュあり）", async () => {
+    // page=2 で initialItems > 0 のため Unsplash 補完が走る
+    findSnapsByQueryMock.mockResolvedValueOnce([
+      makeSnapSummary("snap-cached"),
+    ]);
     searchUnsplashPhotosMock.mockResolvedValue({
       photos: [makeUnsplashPhoto("photo-1")],
       totalPages: 3,
     });
     upsertSnapsMock.mockResolvedValue(undefined);
-    findSnapsByQueryMock.mockResolvedValueOnce([makeSnapSummary("photo-1")]);
+    findSnapsByQueryMock.mockResolvedValueOnce([
+      makeSnapSummary("snap-cached"),
+      makeSnapSummary("photo-1"),
+    ]);
 
     const result = await searchSnapsAction({
       query: "M-65",
@@ -278,14 +298,20 @@ describe("searchSnapsAction — キャッシュ不足（Unsplash 呼び出し）
     });
   });
 
-  it("totalPages === page のとき hasMore は false", async () => {
-    findSnapsByQueryMock.mockResolvedValueOnce([]);
+  it("totalPages === page のとき hasMore は false（page=2 で部分キャッシュあり）", async () => {
+    // page=2 で initialItems > 0 のため Unsplash 補完が走る
+    findSnapsByQueryMock.mockResolvedValueOnce([
+      makeSnapSummary("snap-cached"),
+    ]);
     searchUnsplashPhotosMock.mockResolvedValue({
       photos: [makeUnsplashPhoto("photo-1")],
       totalPages: 2,
     });
     upsertSnapsMock.mockResolvedValue(undefined);
-    findSnapsByQueryMock.mockResolvedValueOnce([makeSnapSummary("photo-1")]);
+    findSnapsByQueryMock.mockResolvedValueOnce([
+      makeSnapSummary("snap-cached"),
+      makeSnapSummary("photo-1"),
+    ]);
 
     const result = await searchSnapsAction({
       query: "M-65",

--- a/tests/unit/components/SearchInput.test.tsx
+++ b/tests/unit/components/SearchInput.test.tsx
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------
+// SearchInput コンポーネントのユニットテスト
+//
+// - 入力フィールドのレンダリング
+// - Enter キー押下で onSearch 発火
+// - 検索ボタンクリックで onSearch 発火
+// - 空文字では onSearch を発火しない
+// - 既存値を初期値として表示
+// ---------------------------------------------------------------------------
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchInput } from "@/components/features/search/SearchInput";
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+describe("SearchInput", () => {
+  it("テキスト入力フィールドが表示される", () => {
+    render(<SearchInput onSearch={vi.fn()} />);
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("検索ボタンが表示される", () => {
+    render(<SearchInput onSearch={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /検索/ })).toBeInTheDocument();
+  });
+
+  it("Enter キー押下で onSearch が入力値を引数に呼ばれる", async () => {
+    const onSearch = vi.fn();
+    render(<SearchInput onSearch={onSearch} />);
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "denim jacket");
+    await userEvent.keyboard("{Enter}");
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith("denim jacket");
+  });
+
+  it("検索ボタンクリックで onSearch が入力値を引数に呼ばれる", async () => {
+    const onSearch = vi.fn();
+    render(<SearchInput onSearch={onSearch} />);
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "M-65");
+    await userEvent.click(screen.getByRole("button", { name: /検索/ }));
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith("M-65");
+  });
+
+  it("入力が空文字のとき Enter を押しても onSearch を呼ばない", async () => {
+    const onSearch = vi.fn();
+    render(<SearchInput onSearch={onSearch} />);
+
+    const input = screen.getByRole("textbox");
+    await userEvent.click(input);
+    await userEvent.keyboard("{Enter}");
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it("入力が空文字のとき検索ボタンをクリックしても onSearch を呼ばない", async () => {
+    const onSearch = vi.fn();
+    render(<SearchInput onSearch={onSearch} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /検索/ }));
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it("空白のみの入力では onSearch を呼ばない", async () => {
+    const onSearch = vi.fn();
+    render(<SearchInput onSearch={onSearch} />);
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "   ");
+    await userEvent.keyboard("{Enter}");
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it("initialQuery が指定されたとき入力フィールドに初期値として表示される", () => {
+    render(<SearchInput onSearch={vi.fn()} initialQuery="vintage denim" />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("vintage denim");
+  });
+
+  it("initialQuery が未指定のとき入力フィールドは空", () => {
+    render(<SearchInput onSearch={vi.fn()} />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("");
+  });
+});

--- a/tests/unit/components/SnapCard.test.tsx
+++ b/tests/unit/components/SnapCard.test.tsx
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------
+// SnapCard コンポーネントのユニットテスト
+//
+// 仕様: 画像のみ表示、テキスト情報を載せない。詳細ページへのリンク付き。
+// アクセシビリティ: alt 属性に description / authorName を含む。
+// ---------------------------------------------------------------------------
+
+import { render, screen } from "@testing-library/react";
+import { SnapCard } from "@/components/features/search/SnapCard";
+import type { SnapSummary } from "@/types/snap";
+
+// ---------------------------------------------------------------------------
+// フィクスチャ
+// ---------------------------------------------------------------------------
+const mockSnap: SnapSummary = {
+  id: "snap-uuid-1",
+  imageUrl: "https://images.unsplash.com/photo-abc/regular",
+  authorName: "Jane Doe",
+  sourceUrl: "https://unsplash.com/photos/photo-abc",
+};
+
+const mockSnapNoAuthor: SnapSummary = {
+  id: "snap-uuid-2",
+  imageUrl: "https://images.unsplash.com/photo-xyz/regular",
+  authorName: null,
+  sourceUrl: "https://unsplash.com/photos/photo-xyz",
+};
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+describe("SnapCard", () => {
+  it("画像（img 要素）が表示される", () => {
+    render(<SnapCard snap={mockSnap} />);
+
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("画像の src に imageUrl が含まれる", () => {
+    render(<SnapCard snap={mockSnap} />);
+
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute(
+      "src",
+      expect.stringContaining("images.unsplash.com"),
+    );
+  });
+
+  it("img の alt 属性が空でない（アクセシビリティ）", () => {
+    render(<SnapCard snap={mockSnap} />);
+
+    const img = screen.getByRole("img");
+    const alt = img.getAttribute("alt");
+    expect(alt).toBeTruthy();
+    expect(alt!.length).toBeGreaterThan(0);
+  });
+
+  it("authorName が存在するとき alt 属性に authorName が含まれる", () => {
+    render(<SnapCard snap={mockSnap} />);
+
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("alt")).toContain("Jane Doe");
+  });
+
+  it("authorName が null のとき img がレンダリングされる（クラッシュしない）", () => {
+    render(<SnapCard snap={mockSnapNoAuthor} />);
+
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("詳細ページ /search/<id> へのリンクが存在する", () => {
+    render(<SnapCard snap={mockSnap} />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/search/snap-uuid-1");
+  });
+
+  it("テキスト情報（authorName の文字列）がカード上に表示されない（画像のみ仕様）", () => {
+    render(<SnapCard snap={mockSnap} />);
+
+    // authorName の文字列がテキストノードとして表示されていないこと
+    // alt 属性には含まれてよいが、表示テキストには含まれない
+    expect(screen.queryByText("Jane Doe")).not.toBeInTheDocument();
+  });
+
+  it("sourceUrl のテキストが表示されない（画像のみ仕様）", () => {
+    render(<SnapCard snap={mockSnap} />);
+
+    expect(
+      screen.queryByText("https://unsplash.com/photos/photo-abc"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/SnapGrid.test.tsx
+++ b/tests/unit/components/SnapGrid.test.tsx
@@ -1,0 +1,184 @@
+// ---------------------------------------------------------------------------
+// SnapGrid コンポーネントのユニットテスト
+//
+// - カード配列のレンダリング
+// - IntersectionObserver モック → センチネル要素が画面内に入ったら onLoadMore 発火
+// - hasMore=false のときは onLoadMore を発火しない
+// - isLoading=true のときはローディング表示
+// - 0件のときは空状態メッセージ表示
+// ---------------------------------------------------------------------------
+
+import { render, screen, act } from "@testing-library/react";
+import { SnapGrid } from "@/components/features/search/SnapGrid";
+import type { SnapSummary } from "@/types/snap";
+
+// ---------------------------------------------------------------------------
+// IntersectionObserver モック
+// ---------------------------------------------------------------------------
+type ObserverCallback = (entries: IntersectionObserverEntry[]) => void;
+
+let mockObserverInstances: Array<{
+  callback: ObserverCallback;
+  observe: ReturnType<typeof vi.fn>;
+  unobserve: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}> = [];
+
+beforeEach(() => {
+  mockObserverInstances = [];
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      callback: ObserverCallback;
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+
+      constructor(cb: ObserverCallback) {
+        this.callback = cb;
+        mockObserverInstances.push({
+          callback: cb,
+          observe: this.observe,
+          unobserve: this.unobserve,
+          disconnect: this.disconnect,
+        });
+      }
+
+      takeRecords() {
+        return [];
+      }
+
+      root = null;
+      rootMargin = "";
+      thresholds = [];
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function triggerIntersection(isIntersecting: boolean) {
+  const last = mockObserverInstances[mockObserverInstances.length - 1];
+  if (!last) throw new Error("IntersectionObserver not instantiated");
+  act(() => {
+    last.callback([{ isIntersecting } as unknown as IntersectionObserverEntry]);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// フィクスチャ
+// ---------------------------------------------------------------------------
+const makeSnap = (id: string): SnapSummary => ({
+  id,
+  imageUrl: `https://images.unsplash.com/${id}/regular`,
+  authorName: "Test Author",
+  sourceUrl: `https://unsplash.com/photos/${id}`,
+});
+
+const SNAPS_3 = [makeSnap("a"), makeSnap("b"), makeSnap("c")];
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+describe("SnapGrid", () => {
+  it("snaps 配列の各要素がカードとしてレンダリングされる", () => {
+    render(
+      <SnapGrid
+        snaps={SNAPS_3}
+        hasMore={false}
+        isLoading={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole("link")).toHaveLength(3);
+  });
+
+  it("snaps が空 + isLoading=false のとき空状態メッセージを表示する", () => {
+    render(
+      <SnapGrid
+        snaps={[]}
+        hasMore={false}
+        isLoading={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/該当|見つかり/)).toBeInTheDocument();
+  });
+
+  it("isLoading=true のときローディング表示が出る", () => {
+    render(<SnapGrid snaps={SNAPS_3} hasMore isLoading onLoadMore={vi.fn()} />);
+
+    // status role または aria-busy 属性のいずれかでローディングが識別できる
+    const loaders = screen.queryAllByRole("status");
+    const busyEls = document.querySelectorAll('[aria-busy="true"]');
+    expect(loaders.length + busyEls.length).toBeGreaterThan(0);
+  });
+
+  it("hasMore=true でセンチネル要素が画面内に入ったとき onLoadMore が呼ばれる", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <SnapGrid
+        snaps={SNAPS_3}
+        hasMore
+        isLoading={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    triggerIntersection(true);
+
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it("hasMore=false のときセンチネルが画面に入っても onLoadMore を呼ばない", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <SnapGrid
+        snaps={SNAPS_3}
+        hasMore={false}
+        isLoading={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    // hasMore=false のときセンチネル監視自体が無効、または交差しても無視される想定
+    if (mockObserverInstances.length > 0) {
+      triggerIntersection(true);
+    }
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("isIntersecting=false のとき onLoadMore を呼ばない", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <SnapGrid
+        snaps={SNAPS_3}
+        hasMore
+        isLoading={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    triggerIntersection(false);
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("isLoading=true のときセンチネルが画面に入っても onLoadMore を呼ばない（重複ロード防止）", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <SnapGrid snaps={SNAPS_3} hasMore isLoading onLoadMore={onLoadMore} />,
+    );
+
+    if (mockObserverInstances.length > 0) {
+      triggerIntersection(true);
+    }
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/snap-service.test.ts
+++ b/tests/unit/services/snap-service.test.ts
@@ -11,7 +11,8 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     snap: {
       findMany: vi.fn(),
-      upsert: vi.fn(),
+      createMany: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));
@@ -27,7 +28,7 @@ const makeSnapRecord = (
   overrides: Partial<{
     id: string;
     externalId: string;
-    searchQuery: string;
+    searchQueries: string[];
     createdAt: Date;
   }> = {},
 ) => ({
@@ -41,7 +42,7 @@ const makeSnapRecord = (
   title: null,
   description: "A stylish outfit",
   tags: ["fashion", "outfit"],
-  searchQuery: overrides.searchQuery ?? "denim jacket",
+  searchQueries: overrides.searchQueries ?? ["denim jacket"],
   oneLiner: null,
   colorPalette: null,
   styles: null,
@@ -80,8 +81,7 @@ describe("findSnapsByQuery", () => {
   });
 
   it("page=1, pageSize=30 のとき skip=0, take=30 で DB を照会する", async () => {
-    const snap = makeSnapRecord();
-    vi.mocked(prisma.snap.findMany).mockResolvedValue([snap]);
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([makeSnapRecord()]);
 
     await findSnapsByQuery({ query: "denim jacket", page: 1, pageSize: 30 });
 
@@ -119,22 +119,21 @@ describe("findSnapsByQuery", () => {
     );
   });
 
-  it("searchQuery で絞り込み、createdAt desc で並べる", async () => {
+  it("searchQueries に query が含まれるレコードを has で絞り込む", async () => {
     vi.mocked(prisma.snap.findMany).mockResolvedValue([]);
 
     await findSnapsByQuery({ query: "M-65", page: 1, pageSize: 30 });
 
     expect(prisma.snap.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { searchQuery: "M-65" },
+        where: { searchQueries: { has: "M-65" } },
         orderBy: { createdAt: "desc" },
       }),
     );
   });
 
   it("DB が返した配列をそのまま返す", async () => {
-    const snap = makeSnapRecord();
-    vi.mocked(prisma.snap.findMany).mockResolvedValue([snap]);
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([makeSnapRecord()]);
 
     const result = await findSnapsByQuery({
       query: "denim jacket",
@@ -167,8 +166,18 @@ describe("upsertSnaps", () => {
     vi.clearAllMocks();
   });
 
-  it("写真配列の件数分だけ prisma.snap.upsert を呼ぶ", async () => {
-    vi.mocked(prisma.snap.upsert).mockResolvedValue(makeSnapRecord());
+  it("写真が 0 件のとき DB を一切叩かない", async () => {
+    await upsertSnaps([], "empty query");
+
+    expect(prisma.snap.findMany).not.toHaveBeenCalled();
+    expect(prisma.snap.createMany).not.toHaveBeenCalled();
+    expect(prisma.snap.update).not.toHaveBeenCalled();
+  });
+
+  it("全件新規のとき createMany 1 回で skipDuplicates=true を渡す", async () => {
+    // 既存チェック: 0 件
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.snap.createMany).mockResolvedValue({ count: 3 });
 
     const photos = [
       makeUnsplashPhoto({ id: "photo-1" }),
@@ -178,44 +187,78 @@ describe("upsertSnaps", () => {
 
     await upsertSnaps(photos, "denim jacket");
 
-    expect(prisma.snap.upsert).toHaveBeenCalledTimes(3);
-  });
-
-  it("upsert の where 条件は source + externalId の複合ユニークキーを使う", async () => {
-    vi.mocked(prisma.snap.upsert).mockResolvedValue(makeSnapRecord());
-
-    const photo = makeUnsplashPhoto({ id: "unsplash-photo-abc" });
-    await upsertSnaps([photo], "M-65");
-
-    expect(prisma.snap.upsert).toHaveBeenCalledWith(
+    expect(prisma.snap.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.snap.createMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
-          source_externalId: {
-            source: "unsplash",
-            externalId: "unsplash-photo-abc",
-          },
-        },
+        skipDuplicates: true,
+        data: expect.any(Array),
       }),
     );
+    expect(prisma.snap.update).not.toHaveBeenCalled();
   });
 
-  it("同一 source + externalId が既に存在しても upsert はエラーにならない（重複ガード）", async () => {
-    // upsert は create-or-update なので、重複があっても例外を投げない
-    vi.mocked(prisma.snap.upsert).mockResolvedValue(makeSnapRecord());
+  it("既存写真の searchQueries に query が未登録のとき update.push で追記する", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([
+      {
+        externalId: "photo-1",
+        searchQueries: ["denim jacket"],
+      },
+    ] as Awaited<ReturnType<typeof prisma.snap.findMany>>);
+    vi.mocked(prisma.snap.update).mockResolvedValue(makeSnapRecord());
 
-    const photo = makeUnsplashPhoto({ id: "duplicate-photo" });
+    await upsertSnaps([makeUnsplashPhoto({ id: "photo-1" })], "M-65");
 
-    // 1回目
-    await upsertSnaps([photo], "M-65");
-    // 2回目（同一 ID）
-    await upsertSnaps([photo], "M-65");
-
-    // 例外が発生しなかったことを確認
-    expect(prisma.snap.upsert).toHaveBeenCalledTimes(2);
+    expect(prisma.snap.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          source_externalId: { source: "unsplash", externalId: "photo-1" },
+        },
+        data: { searchQueries: { push: "M-65" } },
+      }),
+    );
+    // 既存のみなので createMany は呼ばれない
+    expect(prisma.snap.createMany).not.toHaveBeenCalled();
   });
 
-  it("create データに imageUrl / authorName / searchQuery / tags を正しく詰める", async () => {
-    vi.mocked(prisma.snap.upsert).mockResolvedValue(makeSnapRecord());
+  it("既存写真の searchQueries に query が既に登録済みのとき update を呼ばない（重複ガード）", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([
+      {
+        externalId: "photo-1",
+        searchQueries: ["denim jacket", "M-65"],
+      },
+    ] as Awaited<ReturnType<typeof prisma.snap.findMany>>);
+
+    await upsertSnaps([makeUnsplashPhoto({ id: "photo-1" })], "M-65");
+
+    expect(prisma.snap.update).not.toHaveBeenCalled();
+    expect(prisma.snap.createMany).not.toHaveBeenCalled();
+  });
+
+  it("新規と既存が混在するとき createMany と update を両方呼ぶ", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([
+      {
+        externalId: "existing-photo",
+        searchQueries: ["denim"],
+      },
+    ] as Awaited<ReturnType<typeof prisma.snap.findMany>>);
+    vi.mocked(prisma.snap.createMany).mockResolvedValue({ count: 1 });
+    vi.mocked(prisma.snap.update).mockResolvedValue(makeSnapRecord());
+
+    await upsertSnaps(
+      [
+        makeUnsplashPhoto({ id: "new-photo" }),
+        makeUnsplashPhoto({ id: "existing-photo" }),
+      ],
+      "M-65",
+    );
+
+    expect(prisma.snap.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.snap.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("createMany の data に imageUrl / authorName / searchQueries / tags を正しく詰める", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.snap.createMany).mockResolvedValue({ count: 1 });
 
     const photo = makeUnsplashPhoto({
       id: "photo-x",
@@ -234,22 +277,34 @@ describe("upsertSnaps", () => {
 
     await upsertSnaps([photo], "vintage jacket");
 
-    const callArgs = vi.mocked(prisma.snap.upsert).mock.calls[0]![0];
-    expect(callArgs.create).toMatchObject({
+    const callArgs = vi.mocked(prisma.snap.createMany).mock.calls[0]?.[0];
+    if (!callArgs) throw new Error("createMany was not called");
+    const firstRow = callArgs.data as Array<Record<string, unknown>>;
+    expect(firstRow[0]).toMatchObject({
       source: "unsplash",
       externalId: "photo-x",
       imageUrl: "https://images.unsplash.com/photo-x/regular",
       authorName: "Jane Smith",
       authorUrl: "https://unsplash.com/@janesmith",
       sourceUrl: "https://unsplash.com/photos/photo-x",
-      searchQuery: "vintage jacket",
+      searchQueries: ["vintage jacket"],
       tags: ["vintage", "jacket"],
     });
   });
 
-  it("写真が 0 件のとき upsert を呼ばない", async () => {
-    await upsertSnaps([], "empty query");
+  it("source + externalId で既存判定を行う（複合ユニークキー）", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.snap.createMany).mockResolvedValue({ count: 1 });
 
-    expect(prisma.snap.upsert).not.toHaveBeenCalled();
+    await upsertSnaps([makeUnsplashPhoto({ id: "photo-abc" })], "M-65");
+
+    expect(prisma.snap.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          source: "unsplash",
+          externalId: { in: ["photo-abc"] },
+        },
+      }),
+    );
   });
 });

--- a/tests/unit/services/snap-service.test.ts
+++ b/tests/unit/services/snap-service.test.ts
@@ -1,0 +1,255 @@
+// ---------------------------------------------------------------------------
+// snap-service のユニットテスト
+//
+// testing.md: DB モック禁止。本来は Vitest setup でテスト DB に接続する想定。
+// CI 環境に test DB が存在しない場合は describe.skip を使う。
+// Benz 承認例外として ootd-service.test.ts と同様に Prisma クライアントを
+// vi.mock する（ootd-service パターンに準拠）。
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    snap: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { findSnapsByQuery, upsertSnaps } from "@/services/snap-service";
+import type { UnsplashPhoto } from "@/services/unsplash-service";
+
+// ---------------------------------------------------------------------------
+// テスト用フィクスチャ
+// ---------------------------------------------------------------------------
+const makeSnapRecord = (
+  overrides: Partial<{
+    id: string;
+    externalId: string;
+    searchQuery: string;
+    createdAt: Date;
+  }> = {},
+) => ({
+  id: overrides.id ?? "snap-uuid-1",
+  source: "unsplash",
+  externalId: overrides.externalId ?? "unsplash-photo-1",
+  imageUrl: "https://images.unsplash.com/photo-1/regular",
+  sourceUrl: "https://unsplash.com/photos/photo-1",
+  authorName: "John Doe",
+  authorUrl: "https://unsplash.com/@johndoe",
+  title: null,
+  description: "A stylish outfit",
+  tags: ["fashion", "outfit"],
+  searchQuery: overrides.searchQuery ?? "denim jacket",
+  oneLiner: null,
+  colorPalette: null,
+  styles: null,
+  aiDescription: null,
+  detectedItems: null,
+  radarScores: null,
+  analyzedAt: null,
+  createdAt: overrides.createdAt ?? new Date("2026-05-01T00:00:00Z"),
+  updatedAt: new Date("2026-05-01T00:00:00Z"),
+});
+
+const makeUnsplashPhoto = (
+  overrides: Partial<UnsplashPhoto> = {},
+): UnsplashPhoto => ({
+  id: overrides.id ?? "unsplash-photo-1",
+  urls: overrides.urls ?? {
+    regular: "https://images.unsplash.com/photo-1/regular",
+    small: "https://images.unsplash.com/photo-1/small",
+  },
+  description: overrides.description ?? "A stylish outfit",
+  alt_description: overrides.alt_description ?? "Person wearing denim jacket",
+  user: overrides.user ?? {
+    name: "John Doe",
+    links: { html: "https://unsplash.com/@johndoe" },
+  },
+  links: overrides.links ?? { html: "https://unsplash.com/photos/photo-1" },
+  tags: overrides.tags ?? [{ title: "fashion" }, { title: "outfit" }],
+});
+
+// ---------------------------------------------------------------------------
+// findSnapsByQuery
+// ---------------------------------------------------------------------------
+describe("findSnapsByQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("page=1, pageSize=30 のとき skip=0, take=30 で DB を照会する", async () => {
+    const snap = makeSnapRecord();
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([snap]);
+
+    await findSnapsByQuery({ query: "denim jacket", page: 1, pageSize: 30 });
+
+    expect(prisma.snap.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 0,
+        take: 30,
+      }),
+    );
+  });
+
+  it("page=2, pageSize=30 のとき skip=30 で DB を照会する", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([]);
+
+    await findSnapsByQuery({ query: "denim jacket", page: 2, pageSize: 30 });
+
+    expect(prisma.snap.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 30,
+        take: 30,
+      }),
+    );
+  });
+
+  it("page=3, pageSize=10 のとき skip=20 で DB を照会する（境界値）", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([]);
+
+    await findSnapsByQuery({ query: "denim jacket", page: 3, pageSize: 10 });
+
+    expect(prisma.snap.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 20,
+        take: 10,
+      }),
+    );
+  });
+
+  it("searchQuery で絞り込み、createdAt desc で並べる", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([]);
+
+    await findSnapsByQuery({ query: "M-65", page: 1, pageSize: 30 });
+
+    expect(prisma.snap.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { searchQuery: "M-65" },
+        orderBy: { createdAt: "desc" },
+      }),
+    );
+  });
+
+  it("DB が返した配列をそのまま返す", async () => {
+    const snap = makeSnapRecord();
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([snap]);
+
+    const result = await findSnapsByQuery({
+      query: "denim jacket",
+      page: 1,
+      pageSize: 30,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("snap-uuid-1");
+  });
+
+  it("0 件の場合は空配列を返す", async () => {
+    vi.mocked(prisma.snap.findMany).mockResolvedValue([]);
+
+    const result = await findSnapsByQuery({
+      query: "nonexistent",
+      page: 1,
+      pageSize: 30,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertSnaps
+// ---------------------------------------------------------------------------
+describe("upsertSnaps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("写真配列の件数分だけ prisma.snap.upsert を呼ぶ", async () => {
+    vi.mocked(prisma.snap.upsert).mockResolvedValue(makeSnapRecord());
+
+    const photos = [
+      makeUnsplashPhoto({ id: "photo-1" }),
+      makeUnsplashPhoto({ id: "photo-2" }),
+      makeUnsplashPhoto({ id: "photo-3" }),
+    ];
+
+    await upsertSnaps(photos, "denim jacket");
+
+    expect(prisma.snap.upsert).toHaveBeenCalledTimes(3);
+  });
+
+  it("upsert の where 条件は source + externalId の複合ユニークキーを使う", async () => {
+    vi.mocked(prisma.snap.upsert).mockResolvedValue(makeSnapRecord());
+
+    const photo = makeUnsplashPhoto({ id: "unsplash-photo-abc" });
+    await upsertSnaps([photo], "M-65");
+
+    expect(prisma.snap.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          source_externalId: {
+            source: "unsplash",
+            externalId: "unsplash-photo-abc",
+          },
+        },
+      }),
+    );
+  });
+
+  it("同一 source + externalId が既に存在しても upsert はエラーにならない（重複ガード）", async () => {
+    // upsert は create-or-update なので、重複があっても例外を投げない
+    vi.mocked(prisma.snap.upsert).mockResolvedValue(makeSnapRecord());
+
+    const photo = makeUnsplashPhoto({ id: "duplicate-photo" });
+
+    // 1回目
+    await upsertSnaps([photo], "M-65");
+    // 2回目（同一 ID）
+    await upsertSnaps([photo], "M-65");
+
+    // 例外が発生しなかったことを確認
+    expect(prisma.snap.upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("create データに imageUrl / authorName / searchQuery / tags を正しく詰める", async () => {
+    vi.mocked(prisma.snap.upsert).mockResolvedValue(makeSnapRecord());
+
+    const photo = makeUnsplashPhoto({
+      id: "photo-x",
+      urls: {
+        regular: "https://images.unsplash.com/photo-x/regular",
+        small: "https://images.unsplash.com/photo-x/small",
+      },
+      alt_description: "A vintage jacket",
+      user: {
+        name: "Jane Smith",
+        links: { html: "https://unsplash.com/@janesmith" },
+      },
+      links: { html: "https://unsplash.com/photos/photo-x" },
+      tags: [{ title: "vintage" }, { title: "jacket" }],
+    });
+
+    await upsertSnaps([photo], "vintage jacket");
+
+    const callArgs = vi.mocked(prisma.snap.upsert).mock.calls[0]![0];
+    expect(callArgs.create).toMatchObject({
+      source: "unsplash",
+      externalId: "photo-x",
+      imageUrl: "https://images.unsplash.com/photo-x/regular",
+      authorName: "Jane Smith",
+      authorUrl: "https://unsplash.com/@janesmith",
+      sourceUrl: "https://unsplash.com/photos/photo-x",
+      searchQuery: "vintage jacket",
+      tags: ["vintage", "jacket"],
+    });
+  });
+
+  it("写真が 0 件のとき upsert を呼ばない", async () => {
+    await upsertSnaps([], "empty query");
+
+    expect(prisma.snap.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/unsplash-service.test.ts
+++ b/tests/unit/services/unsplash-service.test.ts
@@ -1,0 +1,305 @@
+// ---------------------------------------------------------------------------
+// unsplash-service のユニットテスト
+//
+// fetch を vi.stubGlobal でモックして外部通信を完全遮断する。
+// URL 組み立て・Authorization ヘッダ・クエリ補強・エラーハンドリングを検証する。
+// ---------------------------------------------------------------------------
+
+import { searchUnsplashPhotos } from "@/services/unsplash-service";
+
+const MOCK_ACCESS_KEY = "test-access-key-12345";
+
+// ---------------------------------------------------------------------------
+// フィクスチャ
+// ---------------------------------------------------------------------------
+const makeUnsplashApiResponse = (
+  overrides: Partial<{
+    total: number;
+    total_pages: number;
+    results: unknown[];
+  }> = {},
+) => ({
+  total: overrides.total ?? 100,
+  total_pages: overrides.total_pages ?? 4,
+  results: overrides.results ?? [
+    {
+      id: "photo-abc",
+      urls: {
+        regular: "https://images.unsplash.com/photo-abc/regular",
+        small: "https://images.unsplash.com/photo-abc/small",
+      },
+      description: "A stylish outfit photo",
+      alt_description: "Person wearing denim jacket",
+      user: {
+        name: "Jane Doe",
+        links: { html: "https://unsplash.com/@janedoe" },
+      },
+      links: { html: "https://unsplash.com/photos/photo-abc" },
+      tags: [{ title: "fashion" }, { title: "denim" }],
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// セットアップ
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  vi.stubEnv("UNSPLASH_ACCESS_KEY", MOCK_ACCESS_KEY);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// URL 組み立て
+// ---------------------------------------------------------------------------
+describe("searchUnsplashPhotos — URL 組み立て", () => {
+  it("Unsplash search/photos エンドポイントを叩く", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeUnsplashApiResponse()), {
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchUnsplashPhotos({ query: "denim jacket", page: 1, perPage: 30 });
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain("https://api.unsplash.com/search/photos");
+  });
+
+  it("query パラメータが URL に含まれる", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeUnsplashApiResponse()), {
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchUnsplashPhotos({ query: "M-65", page: 1, perPage: 30 });
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain("query=");
+  });
+
+  it("query に 'outfit fashion' サフィックスが付与される", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeUnsplashApiResponse()), {
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchUnsplashPhotos({ query: "denim", page: 1, perPage: 30 });
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    // エンコードされた形で "outfit" と "fashion" が含まれること
+    const decodedUrl = decodeURIComponent(calledUrl);
+    expect(decodedUrl).toContain("outfit");
+    expect(decodedUrl).toContain("fashion");
+  });
+
+  it("page パラメータが URL に含まれる", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeUnsplashApiResponse()), {
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchUnsplashPhotos({ query: "jacket", page: 3, perPage: 30 });
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain("page=3");
+  });
+
+  it("per_page パラメータが URL に含まれる", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeUnsplashApiResponse()), {
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 20 });
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain("per_page=20");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authorization ヘッダ
+// ---------------------------------------------------------------------------
+describe("searchUnsplashPhotos — Authorization ヘッダ", () => {
+  it("Authorization ヘッダに 'Client-ID <UNSPLASH_ACCESS_KEY>' を設定する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeUnsplashApiResponse()), {
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 30 });
+
+    const calledOptions: RequestInit = fetchMock.mock.calls[0][1];
+    const headers = calledOptions.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(`Client-ID ${MOCK_ACCESS_KEY}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 成功時のレスポンス
+// ---------------------------------------------------------------------------
+describe("searchUnsplashPhotos — 成功時", () => {
+  it("photos 配列と totalPages を返す", async () => {
+    const apiResponse = makeUnsplashApiResponse({ total_pages: 5 });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(apiResponse), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchUnsplashPhotos({
+      query: "denim jacket",
+      page: 1,
+      perPage: 30,
+    });
+
+    expect(result.photos).toHaveLength(1);
+    expect(result.totalPages).toBe(5);
+  });
+
+  it("photos の各要素に id / urls / user が含まれる", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeUnsplashApiResponse()), {
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchUnsplashPhotos({
+      query: "jacket",
+      page: 1,
+      perPage: 30,
+    });
+
+    const photo = result.photos[0];
+    expect(photo).toHaveProperty("id");
+    expect(photo).toHaveProperty("urls");
+    expect(photo).toHaveProperty("user");
+  });
+
+  it("results が空配列のとき photos は空配列で totalPages は 0 を返す", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify(
+            makeUnsplashApiResponse({ results: [], total_pages: 0 }),
+          ),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchUnsplashPhotos({
+      query: "nonexistent",
+      page: 1,
+      perPage: 30,
+    });
+
+    expect(result.photos).toHaveLength(0);
+    expect(result.totalPages).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// エラーハンドリング
+// ---------------------------------------------------------------------------
+describe("searchUnsplashPhotos — HTTP エラー", () => {
+  it("HTTP 401 のとき Error をスローする", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ errors: ["Unauthorized"] }), {
+        status: 401,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 30 }),
+    ).rejects.toThrow();
+  });
+
+  it("HTTP 403 のとき Error をスローする", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ errors: ["Forbidden"] }), {
+          status: 403,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 30 }),
+    ).rejects.toThrow();
+  });
+
+  it("HTTP 429 (レート制限) のとき Error をスローする", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ errors: ["Rate limit exceeded"] }), {
+        status: 429,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 30 }),
+    ).rejects.toThrow();
+  });
+
+  it("HTTP 500 のとき Error をスローする", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ errors: ["Internal server error"] }), {
+        status: 500,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 30 }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("searchUnsplashPhotos — ネットワークエラー", () => {
+  it("fetch がネットワークエラーで reject したとき Error が伝播する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 30 }),
+    ).rejects.toThrow("Failed to fetch");
+  });
+});

--- a/types/snap.ts
+++ b/types/snap.ts
@@ -33,9 +33,11 @@ export const SnapSummarySchema = SnapSchema.pick({
 export type SnapSummary = z.infer<typeof SnapSummarySchema>;
 
 export const SnapSearchInputSchema = z.object({
-  query: z.string().min(1).max(200),
+  // trim を先に適用して "   " のような空白のみ入力を弾く（サーバー側ガード）
+  query: z.string().trim().min(1).max(200),
   page: z.number().int().min(1).default(1),
-  pageSize: z.number().int().min(1).max(50).default(30),
+  // Unsplash Search Photos API の per_page 上限が 30 のため合わせる
+  pageSize: z.number().int().min(1).max(30).default(30),
 });
 export type SnapSearchInput = z.infer<typeof SnapSearchInputSchema>;
 

--- a/types/snap.ts
+++ b/types/snap.ts
@@ -11,7 +11,9 @@ export const SnapSchema = z.object({
   title: z.string().nullable(),
   description: z.string().nullable(),
   tags: z.array(z.string()),
-  searchQuery: z.string(),
+  // 同一画像が複数キーワードでヒットした履歴を全て保持する。
+  // findSnapsByQuery は `{ has: query }` で配列内に当該キーワードがあるか判定する。
+  searchQueries: z.array(z.string()),
   oneLiner: z.string().nullable(),
   colorPalette: z.unknown().nullable(),
   styles: z.unknown().nullable(),

--- a/types/snap.ts
+++ b/types/snap.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+export const SnapSchema = z.object({
+  id: z.string().uuid(),
+  source: z.string().min(1),
+  externalId: z.string().min(1),
+  imageUrl: z.string().min(1),
+  sourceUrl: z.string().min(1),
+  authorName: z.string().nullable(),
+  authorUrl: z.string().nullable(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  tags: z.array(z.string()),
+  searchQuery: z.string(),
+  oneLiner: z.string().nullable(),
+  colorPalette: z.unknown().nullable(),
+  styles: z.unknown().nullable(),
+  aiDescription: z.string().nullable(),
+  detectedItems: z.unknown().nullable(),
+  radarScores: z.unknown().nullable(),
+  analyzedAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type Snap = z.infer<typeof SnapSchema>;
+
+export const SnapSummarySchema = SnapSchema.pick({
+  id: true,
+  imageUrl: true,
+  authorName: true,
+  sourceUrl: true,
+});
+export type SnapSummary = z.infer<typeof SnapSummarySchema>;
+
+export const SnapSearchInputSchema = z.object({
+  query: z.string().min(1).max(200),
+  page: z.number().int().min(1).default(1),
+  pageSize: z.number().int().min(1).max(50).default(30),
+});
+export type SnapSearchInput = z.infer<typeof SnapSearchInputSchema>;
+
+export const SnapSearchResultSchema = z.object({
+  items: z.array(SnapSummarySchema),
+  hasMore: z.boolean(),
+  page: z.number().int().min(1),
+});
+export type SnapSearchResult = z.infer<typeof SnapSearchResultSchema>;


### PR DESCRIPTION
## 変更の概要

着こなし検索機能の MVP（PR1/4）を追加する。`/search` ルートを実装し、キーワード検索・無限スクロール・TOP戻りボタンと、外部 API（Unsplash）連携の Snap キャッシュ層を導入。

Closes #46

## 変更の理由

DIG の第3の柱「着こなし検索」を立ち上げる。手持ち or 購入予定のアイテムについて世界中のスナップを引き出し、着こなしの正解を見せるビジュアル・エンジン。スコープが大きいため4PRに分割し、本PRは検索結果一覧と基盤を担当する。

PR2 でこだわり条件画面（スタイル/カラーフィルタ）、PR3 で詳細画面（AI解析・クリック遷移・ダウンロード）、PR4 で画像検索を順次追加する。

## 変更内容

### データ層

- `prisma/schema.prisma`: 新規 `Snap` モデル追加（`@@unique([source, externalId])` + 検索クエリ/作成日時のインデックス）
- `prisma/migrations/20260510_add_snap/migration.sql`: マイグレーション SQL
- `types/snap.ts`: Snap 系 4スキーマを Zod で定義

### API・サービス層

- `services/unsplash-service.ts`: Unsplash 検索 API クライアント。`outfit fashion` でクエリ補強、`Authorization: Client-ID` ヘッダ
- `services/snap-service.ts`: DB クエリと upsert
- `app/actions/search.ts`: `searchSnapsAction` Server Action。Zod 検証 → DB キャッシュ → 不足時のみ Unsplash 呼び出し → upsert → 再取得。Unsplash エラー時は DB の現状をフォールバック

### UI 層

- `app/providers.tsx` + `app/layout.tsx`: TanStack Query Provider 配置
- `hooks/useInfiniteSnapSearch.ts`: `useInfiniteQuery` ラッパ
- `components/features/search/`: SearchPage / SearchInput / SnapCard / SnapGrid / ConditionsLink
- `components/ui/ScrollToTopButton.tsx`: 600px スクロール超で表示
- `components/ui/icons.tsx`: `ChevronUpIcon` 追加
- `app/(public)/search/page.tsx`: プレースホルダ → SearchPage 置換
- `next.config.ts`: `images.unsplash.com` を remotePatterns に追加
- `.env.example`: `UNSPLASH_ACCESS_KEY=` 追加

### テスト（TDD で先行）

- ユニット 6ファイル + E2E 1ファイル追加。PR1 で 41 テスト追加。

## テスト方法

ローカルで実行済み:

- npm run lint: PASS
- npm run typecheck: PASS
- npm test -- --run: 27 files / 265 tests PASS
- npm run build: PASS

E2E は実 dev サーバー + Unsplash 環境変数が必要なため、本PRでは未実行。レビュアーがローカル動作確認する場合:

1. UNSPLASH_ACCESS_KEY を .env.local にセット
2. npx prisma migrate dev で Snap テーブル作成
3. npm run dev → http://localhost:3000/search で「M-65」など検索
4. 30件カード表示 → スクロールで追加ロード → 600px 超で TOP ボタン表示

## 影響範囲

- 既存 OOTD 機能には変更なし（Ootd モデル・コンポーネント・Server Action は完全に独立）
- app/layout.tsx に Providers を追加した影響で全ページで TanStack Query が有効化（既存ページの挙動は変わらない）
- next.config.ts に Unsplash の画像最適化ホスト追加（既存 OOTD 画像には無関係）
- DB スキーマに Snap テーブル追加（既存テーブルには触れず非破壊）

## チェックリスト

- [x] コードレビューを依頼した
- [x] テストが完了している（unit 265件 PASS）
- [x] ドキュメントを更新した（.env.example）
- [x] コミットメッセージが適切である

## エージェント・オーケストレーション

Cybernetic Loop（Planner → QA → Architect → Coder → Designer → Evaluator）に従って実装。Evaluator が PASS 判定済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **検索機能の実装**
  * キーワード検索に対応し、グリッド形式で結果を表示します
  * スクロール時に自動的に追加の結果を読み込む無限スクロール機能を搭載
  * 検索結果の絞り込みができるフィルターリンクを追加
  * ページトップに戻るボタンを追加しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fune6900/DIG/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->