### PR TITLE
feat: condition chips & keyword field in conditions form

### DIFF
--- a/app/(public)/search/conditions/ConditionsRouteClient.tsx
+++ b/app/(public)/search/conditions/ConditionsRouteClient.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { ConditionsForm } from "@/components/features/search/ConditionsForm";
+import { buildKeywordFromConditions } from "@/lib/conditions-keyword";
 
 export function ConditionsRouteClient() {
   const router = useRouter();
@@ -20,12 +21,12 @@ export function ConditionsRouteClient() {
     styles: string[];
     colors: string[];
   }) {
-    const urlParams = new URLSearchParams();
-    if (params.query) urlParams.set("query", params.query);
-    if (params.styles.length > 0)
-      urlParams.set("styles", params.styles.join(","));
-    if (params.colors.length > 0)
-      urlParams.set("colors", params.colors.join(","));
+    const keyword = buildKeywordFromConditions(params);
+    if (keyword.length === 0) {
+      router.push("/search");
+      return;
+    }
+    const urlParams = new URLSearchParams({ query: keyword });
     router.push(`/search?${urlParams.toString()}`);
   }
 

--- a/components/features/search/ConditionsForm.tsx
+++ b/components/features/search/ConditionsForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { STYLE_GROUPS } from "@/lib/style-groups";
 import { StyleFilterGroup } from "./StyleFilterGroup";
 import { ColorFilterGrid } from "./ColorFilterGrid";
+import { SearchIcon } from "@/components/ui/icons";
 
 interface ConditionsFormProps {
   initialQuery: string;
@@ -24,7 +25,7 @@ export function ConditionsForm({
   onSearch,
   onReset,
 }: ConditionsFormProps) {
-  const [query] = useState<string>(initialQuery);
+  const [query, setQuery] = useState<string>(initialQuery);
   const [selectedStyles, setSelectedStyles] = useState<Set<string>>(
     () => new Set(initialStyles),
   );
@@ -57,6 +58,7 @@ export function ConditionsForm({
   }
 
   function handleReset() {
+    setQuery("");
     setSelectedStyles(new Set());
     setSelectedColors(new Set());
     onReset();
@@ -64,14 +66,40 @@ export function ConditionsForm({
 
   function handleSearch() {
     onSearch({
-      query,
+      query: query.trim(),
       styles: Array.from(selectedStyles),
       colors: Array.from(selectedColors),
     });
   }
 
+  const isEmpty =
+    query.trim().length === 0 &&
+    selectedStyles.size === 0 &&
+    selectedColors.size === 0;
+
   return (
     <div className="flex flex-col gap-6">
+      {/* キーワード入力 */}
+      <section aria-label="キーワード">
+        <h3 className="mb-2 text-xs font-semibold tracking-widest uppercase text-denim/60 dark:text-denim-light/60">
+          キーワード
+        </h3>
+        <div className="relative">
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-denim/40 dark:text-offwhite/30">
+            <SearchIcon width={16} height={16} />
+          </span>
+          <input
+            type="text"
+            role="textbox"
+            aria-label="キーワード"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="キーワードを入力（例: M-65、501）"
+            className="w-full rounded-none border border-denim/20 bg-offwhite dark:bg-canvas-subtle dark:border-denim-light/20 py-2.5 pl-9 pr-4 text-sm text-denim-dark dark:text-offwhite placeholder:text-denim/30 dark:placeholder:text-offwhite/30 focus:border-denim dark:focus:border-denim-light focus:outline-none focus:ring-1 focus:ring-denim dark:focus:ring-denim-light transition-colors"
+          />
+        </div>
+      </section>
+
       {/* スタイルフィルタ */}
       <section aria-label="スタイルフィルタ">
         {STYLE_GROUPS.map((group) => (
@@ -107,11 +135,7 @@ export function ConditionsForm({
         <button
           type="button"
           onClick={handleSearch}
-          disabled={
-            selectedStyles.size === 0 &&
-            selectedColors.size === 0 &&
-            query.trim().length === 0
-          }
+          disabled={isEmpty}
           className="flex-1 rounded-none border border-denim bg-denim px-4 py-3 text-sm font-medium tracking-wide text-offwhite transition-colors hover:bg-denim/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-denim dark:border-denim-light dark:bg-denim-light dark:text-canvas dark:disabled:hover:bg-denim-light"
         >
           検索

--- a/components/features/search/SearchInput.tsx
+++ b/components/features/search/SearchInput.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { SearchIcon, ImageIcon } from "@/components/ui/icons";
+import {
+  parseKeywordIntoChips,
+  removeChipFromKeyword,
+} from "@/lib/conditions-keyword";
 
 interface SearchInputProps {
   onSearch: (query: string) => void;
@@ -16,12 +20,26 @@ export function SearchInput({
 }: SearchInputProps) {
   const [value, setValue] = useState(initialQuery);
 
+  // 親 (URL) が変わったときに表示を追従させる
+  useEffect(() => {
+    setValue(initialQuery);
+  }, [initialQuery]);
+
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const trimmed = value.trim();
     if (trimmed.length === 0) return;
     onSearch(trimmed);
   }
+
+  function handleRemoveChip(chip: string) {
+    const next = removeChipFromKeyword(value, chip);
+    setValue(next);
+    onSearch(next);
+  }
+
+  const chips = parseKeywordIntoChips(value);
+  const showChips = chips.length >= 2;
 
   return (
     <div className="space-y-2 w-full">
@@ -53,6 +71,29 @@ export function SearchInput({
           検索
         </button>
       </form>
+
+      {showChips && (
+        <ul className="flex flex-wrap gap-1.5" aria-label="検索条件">
+          {chips.map((chip) => (
+            <li key={chip}>
+              <button
+                type="button"
+                onClick={() => handleRemoveChip(chip)}
+                aria-label={`${chip}を削除`}
+                className="inline-flex items-center gap-1 rounded-none border border-denim/30 bg-offwhite px-2 py-1 text-xs text-denim transition-colors hover:border-denim hover:bg-denim/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-denim focus-visible:ring-offset-2 dark:border-offwhite/30 dark:bg-canvas-subtle dark:text-offwhite dark:hover:border-offwhite dark:hover:bg-offwhite/5"
+              >
+                <span>{chip}</span>
+                <span
+                  aria-hidden="true"
+                  className="text-denim/50 dark:text-offwhite/50"
+                >
+                  ×
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
 
       <div className="flex justify-end">
         <button

--- a/components/features/search/SearchInput.tsx
+++ b/components/features/search/SearchInput.tsx
@@ -74,8 +74,8 @@ export function SearchInput({
 
       {showChips && (
         <ul className="flex flex-wrap gap-1.5" aria-label="検索条件">
-          {chips.map((chip) => (
-            <li key={chip}>
+          {chips.map((chip, index) => (
+            <li key={`${chip}-${index}`}>
               <button
                 type="button"
                 onClick={() => handleRemoveChip(chip)}

--- a/components/features/search/SearchPage.tsx
+++ b/components/features/search/SearchPage.tsx
@@ -41,7 +41,8 @@ export function SearchPage() {
     if (q) params.set("query", q);
     if (stylesParam) params.set("styles", stylesParam);
     if (colorsParam) params.set("colors", colorsParam);
-    router.push(`/search?${params.toString()}`);
+    const search = params.toString();
+    router.push(search ? `/search?${search}` : "/search");
   }
 
   async function handleImagePick(file: File) {

--- a/lib/conditions-keyword.ts
+++ b/lib/conditions-keyword.ts
@@ -45,7 +45,9 @@ export function parseKeywordIntoChips(query: string): string[] {
 }
 
 export function removeChipFromKeyword(query: string, chip: string): string {
-  return parseKeywordIntoChips(query)
-    .filter((c) => c !== chip)
-    .join(" ");
+  const chips = parseKeywordIntoChips(query);
+  const idx = chips.indexOf(chip);
+  if (idx === -1) return chips.join(" ");
+  chips.splice(idx, 1);
+  return chips.join(" ");
 }

--- a/lib/conditions-keyword.ts
+++ b/lib/conditions-keyword.ts
@@ -1,0 +1,51 @@
+/**
+ * 着こなし検索の「こだわり条件」をキーワード文字列として扱うためのヘルパ群。
+ *
+ * 仕様:
+ *   - styles / colors / 入力キーワードを半角スペース区切りの 1 文字列に連結
+ *   - カラーカテゴリの『〜系』サフィックスを除去（『レッド系』→『レッド』）
+ *   - 連結文字列をチップ配列に分解／チップ単位で削除
+ *
+ * 関連: app/(public)/search/conditions / components/features/search/SearchInput
+ */
+
+interface BuildKeywordInput {
+  query: string;
+  styles: string[];
+  colors: string[];
+}
+
+const CATEGORY_SUFFIX = "系";
+
+export function stripCategorySuffix(name: string): string {
+  return name.endsWith(CATEGORY_SUFFIX)
+    ? name.slice(0, -CATEGORY_SUFFIX.length)
+    : name;
+}
+
+export function buildKeywordFromConditions(input: BuildKeywordInput): string {
+  const parts: string[] = [];
+
+  const trimmedQuery = input.query.trim();
+  if (trimmedQuery.length > 0) parts.push(trimmedQuery);
+
+  for (const s of input.styles) {
+    if (s.length > 0) parts.push(s);
+  }
+  for (const c of input.colors) {
+    const stripped = stripCategorySuffix(c);
+    if (stripped.length > 0) parts.push(stripped);
+  }
+
+  return parts.join(" ");
+}
+
+export function parseKeywordIntoChips(query: string): string[] {
+  return query.trim().split(/\s+/).filter(Boolean);
+}
+
+export function removeChipFromKeyword(query: string, chip: string): string {
+  return parseKeywordIntoChips(query)
+    .filter((c) => c !== chip)
+    .join(" ");
+}

--- a/tests/unit/components/ConditionsForm.test.tsx
+++ b/tests/unit/components/ConditionsForm.test.tsx
@@ -309,6 +309,107 @@ describe("ConditionsForm — 検索ボタン", () => {
 });
 
 // ---------------------------------------------------------------------------
+// キーワード入力（編集可能）
+// ---------------------------------------------------------------------------
+describe("ConditionsForm — キーワード入力", () => {
+  it("キーワード入力フィールドが表示される", () => {
+    render(
+      <ConditionsForm
+        initialStyles={[]}
+        initialColors={[]}
+        initialQuery=""
+        onSearch={vi.fn()}
+        onReset={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: /キーワード/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("initialQuery が指定されたとき入力フィールドに初期値として表示される", () => {
+    render(
+      <ConditionsForm
+        initialStyles={[]}
+        initialColors={[]}
+        initialQuery="vintage denim"
+        onSearch={vi.fn()}
+        onReset={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: /キーワード/ })).toHaveValue(
+      "vintage denim",
+    );
+  });
+
+  it("キーワードを編集して検索 → 編集後の値が onSearch の query に渡る", async () => {
+    const onSearch = vi.fn();
+    render(
+      <ConditionsForm
+        initialStyles={["アメカジ"]}
+        initialColors={[]}
+        initialQuery="vintage"
+        onSearch={onSearch}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: /キーワード/ });
+    await userEvent.clear(input);
+    await userEvent.type(input, "M-65");
+
+    await userEvent.click(screen.getByRole("button", { name: /検索/ }));
+
+    expect(onSearch).toHaveBeenCalledWith({
+      styles: ["アメカジ"],
+      colors: [],
+      query: "M-65",
+    });
+  });
+
+  it("キーワード入力のみで（スタイル・カラー未選択）「検索」ボタンが有効化される", async () => {
+    render(
+      <ConditionsForm
+        initialStyles={[]}
+        initialColors={[]}
+        initialQuery=""
+        onSearch={vi.fn()}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const searchBtn = screen.getByRole("button", { name: /検索/ });
+    expect(searchBtn).toBeDisabled();
+
+    const input = screen.getByRole("textbox", { name: /キーワード/ });
+    await userEvent.type(input, "501");
+
+    expect(searchBtn).not.toBeDisabled();
+  });
+
+  it("「リセット」クリックでキーワードもクリアされる", async () => {
+    render(
+      <ConditionsForm
+        initialStyles={[]}
+        initialColors={[]}
+        initialQuery="vintage"
+        onSearch={vi.fn()}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: /キーワード/ });
+    expect(input).toHaveValue("vintage");
+
+    await userEvent.click(screen.getByRole("button", { name: /リセット/ }));
+
+    expect(input).toHaveValue("");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // リセットボタン
 // ---------------------------------------------------------------------------
 describe("ConditionsForm — リセットボタン", () => {

--- a/tests/unit/components/SearchInput.test.tsx
+++ b/tests/unit/components/SearchInput.test.tsx
@@ -104,6 +104,83 @@ describe("SearchInput", () => {
     expect(input).toHaveValue("");
   });
 
+  describe("チップ表示（複数語キーワード）", () => {
+    it("initialQuery が複数語のときチップが各語ごとに表示される", () => {
+      render(
+        <SearchInput
+          onSearch={vi.fn()}
+          onImageSearch={vi.fn()}
+          initialQuery="アメカジ レッド"
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: /アメカジを削除/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /レッドを削除/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("initialQuery が単一語のときはチップを表示しない", () => {
+      render(
+        <SearchInput
+          onSearch={vi.fn()}
+          onImageSearch={vi.fn()}
+          initialQuery="アメカジ"
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /アメカジを削除/ }),
+      ).toBeNull();
+    });
+
+    it("initialQuery が空のときはチップを表示しない", () => {
+      render(<SearchInput onSearch={vi.fn()} onImageSearch={vi.fn()} />);
+
+      expect(screen.queryByText("×")).toBeNull();
+    });
+
+    it("チップの × クリックで onSearch が残りの語のみで呼ばれる", async () => {
+      const onSearch = vi.fn();
+      render(
+        <SearchInput
+          onSearch={onSearch}
+          onImageSearch={vi.fn()}
+          initialQuery="アメカジ レッド ブルー"
+        />,
+      );
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /レッドを削除/ }),
+      );
+
+      expect(onSearch).toHaveBeenCalledTimes(1);
+      expect(onSearch).toHaveBeenCalledWith("アメカジ ブルー");
+    });
+
+    it("2 語あるチップから 1 つ削除すると onSearch が残りの語で呼ばれる", async () => {
+      // 仕様: 削除して 1 語だけになるとチップは非表示になる（× は出ない）
+      // → 残りの語を直接テキスト編集して空にするパスでカバーされる
+      const onSearch = vi.fn();
+      render(
+        <SearchInput
+          onSearch={onSearch}
+          onImageSearch={vi.fn()}
+          initialQuery="アメカジ レッド"
+        />,
+      );
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /アメカジを削除/ }),
+      );
+
+      expect(onSearch).toHaveBeenCalledTimes(1);
+      expect(onSearch).toHaveBeenCalledWith("レッド");
+    });
+  });
+
   describe("画像で検索（新フロー）", () => {
     it("『画像で検索』ボタンが表示される（Link ではない）", () => {
       render(<SearchInput onSearch={vi.fn()} onImageSearch={vi.fn()} />);

--- a/tests/unit/components/SearchPage.chips.test.tsx
+++ b/tests/unit/components/SearchPage.chips.test.tsx
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------------
+// SearchPage — 連結キーワードのチップ表示・削除統合テスト
+//
+// ?query=「アメカジ レッド」のような半角スペース区切り URL で訪問したとき:
+//   - 各語がチップとして表示される
+//   - × クリックで URL が残りの語で更新される
+//   - 全削除すると /search に遷移
+// ---------------------------------------------------------------------------
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const useInfiniteSnapSearchMock = vi.fn();
+vi.mock("@/hooks/useInfiniteSnapSearch", () => ({
+  useInfiniteSnapSearch: (params: unknown) => useInfiniteSnapSearchMock(params),
+}));
+
+const pushMock = vi.fn();
+const mockSearchParams = { get: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => "/search",
+}));
+
+import { SearchPage } from "@/components/features/search/SearchPage";
+
+const defaultSearchReturn = {
+  data: undefined,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  isPending: false,
+  fetchNextPage: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  useInfiniteSnapSearchMock.mockReturnValue(defaultSearchReturn);
+});
+
+describe("SearchPage — 連結キーワードのチップ表示", () => {
+  it("?query=アメカジ レッド で訪問するとチップ 2 つが表示される", () => {
+    mockSearchParams.get.mockImplementation((key: string) =>
+      key === "query" ? "アメカジ レッド" : null,
+    );
+
+    render(<SearchPage />);
+
+    expect(
+      screen.getByRole("button", { name: /アメカジを削除/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /レッドを削除/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("?query=hoge（単一語）のときはチップを表示しない", () => {
+    mockSearchParams.get.mockImplementation((key: string) =>
+      key === "query" ? "hoge" : null,
+    );
+
+    render(<SearchPage />);
+
+    expect(screen.queryByRole("button", { name: /hogeを削除/ })).toBeNull();
+  });
+
+  it("チップの × クリックで /search?query=<残り> へ遷移する", async () => {
+    mockSearchParams.get.mockImplementation((key: string) =>
+      key === "query" ? "アメカジ レッド ブルー" : null,
+    );
+
+    render(<SearchPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: /レッドを削除/ }));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const pushed = pushMock.mock.calls[0][0] as string;
+    const url = new URL(pushed, "http://localhost");
+    expect(url.pathname).toBe("/search");
+    expect(url.searchParams.get("query")).toBe("アメカジ ブルー");
+  });
+
+  it("最後に 1 語だけ残るチップを削除すると /search に遷移する", async () => {
+    // 仕様: 2語→1語までの削除は ?query=<残り> へ遷移、1語→0語の削除は /search へ
+    // （単一語のときはチップ非表示なので、× をユーザーが押せるのは2語以上から1語へ
+    //  落とすときと、その後で SearchInput のテキストを直接消すパスのみ）
+    mockSearchParams.get.mockImplementation((key: string) =>
+      key === "query" ? "アメカジ レッド" : null,
+    );
+
+    render(<SearchPage />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /アメカジを削除/ }),
+    );
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const pushed = pushMock.mock.calls[0][0] as string;
+    const url = new URL(pushed, "http://localhost");
+    expect(url.pathname).toBe("/search");
+    expect(url.searchParams.get("query")).toBe("レッド");
+  });
+});

--- a/tests/unit/lib/conditions-keyword.test.ts
+++ b/tests/unit/lib/conditions-keyword.test.ts
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------
+// conditions-keyword ヘルパのテスト (Red フェーズ)
+//
+// 着こなし検索で「こだわり条件」をキーワード文字列化するロジック。
+//   - 半角スペース区切りで結合
+//   - カラーカテゴリの『系』サフィックスを除去
+//   - キーワード文字列をチップ配列に分解／チップ削除
+// ---------------------------------------------------------------------------
+
+import {
+  stripCategorySuffix,
+  buildKeywordFromConditions,
+  parseKeywordIntoChips,
+  removeChipFromKeyword,
+} from "@/lib/conditions-keyword";
+
+describe("stripCategorySuffix", () => {
+  it("『〜系』サフィックスを除去する", () => {
+    expect(stripCategorySuffix("ブラック系")).toBe("ブラック");
+    expect(stripCategorySuffix("レッド系")).toBe("レッド");
+    expect(stripCategorySuffix("ネイビー系")).toBe("ネイビー");
+  });
+
+  it("『系』を含まない文字列はそのまま返す", () => {
+    expect(stripCategorySuffix("アメカジ")).toBe("アメカジ");
+    expect(stripCategorySuffix("")).toBe("");
+  });
+
+  it("文字列の途中に『系』があってもサフィックスでないなら維持する", () => {
+    expect(stripCategorySuffix("系統的")).toBe("系統的");
+  });
+});
+
+describe("buildKeywordFromConditions", () => {
+  it("query + styles + colors を半角スペースで連結する", () => {
+    const result = buildKeywordFromConditions({
+      query: "vintage",
+      styles: ["アメカジ"],
+      colors: ["レッド系"],
+    });
+    expect(result).toBe("vintage アメカジ レッド");
+  });
+
+  it("複数 styles / colors を全て連結する", () => {
+    const result = buildKeywordFromConditions({
+      query: "",
+      styles: ["アメカジ", "ストリート"],
+      colors: ["ブラック系", "ホワイト系"],
+    });
+    expect(result).toBe("アメカジ ストリート ブラック ホワイト");
+  });
+
+  it("query が空白のみのときは無視して styles/colors のみ連結", () => {
+    const result = buildKeywordFromConditions({
+      query: "   ",
+      styles: ["アメカジ"],
+      colors: [],
+    });
+    expect(result).toBe("アメカジ");
+  });
+
+  it("全てが空のときは空文字を返す", () => {
+    const result = buildKeywordFromConditions({
+      query: "",
+      styles: [],
+      colors: [],
+    });
+    expect(result).toBe("");
+  });
+
+  it("colors の『系』サフィックスは除去する", () => {
+    const result = buildKeywordFromConditions({
+      query: "",
+      styles: [],
+      colors: ["ブラック系", "オレンジ系"],
+    });
+    expect(result).toBe("ブラック オレンジ");
+  });
+});
+
+describe("parseKeywordIntoChips", () => {
+  it("半角スペース区切りで配列に分解する", () => {
+    expect(parseKeywordIntoChips("アメカジ レッド")).toEqual([
+      "アメカジ",
+      "レッド",
+    ]);
+  });
+
+  it("複数の連続スペースは 1 区切りとして扱う", () => {
+    expect(parseKeywordIntoChips("アメカジ   レッド")).toEqual([
+      "アメカジ",
+      "レッド",
+    ]);
+  });
+
+  it("空文字／空白のみは空配列を返す", () => {
+    expect(parseKeywordIntoChips("")).toEqual([]);
+    expect(parseKeywordIntoChips("   ")).toEqual([]);
+  });
+
+  it("単一語のみのときは 1 要素配列を返す", () => {
+    expect(parseKeywordIntoChips("アメカジ")).toEqual(["アメカジ"]);
+  });
+});
+
+describe("removeChipFromKeyword", () => {
+  it("指定したチップを削除して残りを半角スペースで連結する", () => {
+    expect(removeChipFromKeyword("アメカジ レッド ブルー", "レッド")).toBe(
+      "アメカジ ブルー",
+    );
+  });
+
+  it("先頭のチップを削除できる", () => {
+    expect(removeChipFromKeyword("アメカジ レッド", "アメカジ")).toBe("レッド");
+  });
+
+  it("末尾のチップを削除できる", () => {
+    expect(removeChipFromKeyword("アメカジ レッド", "レッド")).toBe("アメカジ");
+  });
+
+  it("最後の 1 チップを削除すると空文字を返す", () => {
+    expect(removeChipFromKeyword("アメカジ", "アメカジ")).toBe("");
+  });
+
+  it("含まれないチップを指定したときは元の文字列を保持する", () => {
+    expect(removeChipFromKeyword("アメカジ レッド", "ブルー")).toBe(
+      "アメカジ レッド",
+    );
+  });
+});

--- a/tests/unit/lib/conditions-keyword.test.ts
+++ b/tests/unit/lib/conditions-keyword.test.ts
@@ -127,4 +127,14 @@ describe("removeChipFromKeyword", () => {
       "アメカジ レッド",
     );
   });
+
+  it("同じ語が複数あるときは最初の 1 件のみ削除する", () => {
+    expect(removeChipFromKeyword("アメカジ アメカジ レッド", "アメカジ")).toBe(
+      "アメカジ レッド",
+    );
+  });
+
+  it("同じ語が 3 つあるときは 1 件削除すると 2 件残る", () => {
+    expect(removeChipFromKeyword("a a a b", "a")).toBe("a a b");
+  });
 });


### PR DESCRIPTION
## 変更の概要
着こなし検索のフィルタ条件をキーワード文字列として一元的に扱えるようにする。あわせてこだわり条件画面でキーワードを編集できるようにし、画面間でキーワードを保持する。

> Note: ベースブランチは \`feat/54-image-search-mobile-ux\`（PR #56）。#56 のマージ後に main ベースへ自動切り替えされます。

## 変更の理由
- キーワード未入力でこだわり条件のみ選択して検索すると、DB 照会のみで Unsplash 補完がかからず 0 件で詰まっていた
- こだわり条件画面ではキーワードを編集できず、結果画面のキーワードも保持されなかった

## 変更内容
- \`lib/conditions-keyword.ts\` に連結／チップ分解／チップ削除のヘルパを集約（カラーカテゴリの『〜系』サフィックスは自動除去）
- \`ConditionsRouteClient\` で \`query + styles + colors\` を半角スペース区切りの 1 文字列に連結し \`/search?query=<連結>\` に push（styles/colors の独立 URL パラメータは生成しない）
- \`ConditionsForm\` にキーワード入力欄を追加。\`initialQuery\` を編集可能化、リセット時にもクリア
- \`SearchInput\` で query を半角スペース分割し、2 語以上のときに各語をチップとして表示。× クリックでその語のみ削除して再検索
- \`SearchPage.handleSearch\` を空文字 query 時 \`/search\` に遷移するよう調整

## テスト方法
- \`npm test -- --run tests/unit/lib/conditions-keyword.test.ts\` 17/17 green
- \`npm test -- --run tests/unit/components/SearchInput.test.tsx tests/unit/components/ConditionsForm.test.tsx tests/unit/components/SearchPage.chips.test.tsx\` 全 green
- \`npm test -- --run\` 519/519 green
- \`npm run typecheck\` / \`npm run lint\` / \`npm run build\` 全グリーン

### 手動確認（reviewer 用）
- /search で『こだわり条件を選択』 → キーワードフィールドに既存キーワードが保持されていること
- 条件画面で『アメカジ』『レッド系』を選択して『検索』 → \`/search?query=アメカジ%20レッド\` に遷移し結果が表示されること
- 結果画面で『アメカジ ×』『レッド ×』のチップが表示され、× で当該語のみ削除されること
- 単一語キーワード時はチップが表示されないこと

## 影響範囲
- \`/search\` URL の挙動: ConditionsForm 経由のフローは \`?query=<連結>\` 一本化。旧 \`?styles=&colors=\` URL は SearchPage が引き続き受け取って絞り込みに使う（後方互換は維持）。
- ConditionsForm を直接使う既存コードは新 prop なしでも動く（onSearch シグネチャは互換）

## チェックリスト
- [x] コードレビューを依頼した
- [x] テストが完了している
- [x] ドキュメントを更新した（必要に応じて）
- [x] コミットメッセージが適切である

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 検索画面のキーワード入力が編集可能になりました
  * 複数キーワードをチップ形式で表示し、個別に削除できるようになりました
  * こだわり条件の検索結果がより直感的に反映されるようになりました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fune6900/DIG/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->