### PR TITLE
feat: introduce motion library and base primitives

### DIFF
--- a/components/ui/motion/FadeIn.tsx
+++ b/components/ui/motion/FadeIn.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import type { ReactNode } from "react";
+
+type FadeInTag = "div" | "section" | "article" | "li" | "ul" | "header";
+
+const MOTION_TAGS = {
+  div: motion.div,
+  section: motion.section,
+  article: motion.article,
+  li: motion.li,
+  ul: motion.ul,
+  header: motion.header,
+} as const;
+
+interface FadeInProps {
+  children: ReactNode;
+  /** ビューポート侵入からの遅延 (秒) */
+  delay?: number;
+  /** アニメーション尺 (秒) */
+  duration?: number;
+  /** 初期 Y オフセット (px)。0 にすると純粋な fade */
+  y?: number;
+  /** 一度だけ発火するか（再進入で再生し直さない） */
+  once?: boolean;
+  /** ラップ要素のタグ */
+  as?: FadeInTag;
+  className?: string;
+}
+
+/**
+ * ビューポート侵入時に fade + slide up でコンテンツを表示する。
+ * prefers-reduced-motion: reduce ではアニメーションを完全に無効化し
+ * children を即時表示する（アクセシビリティ）。
+ */
+export function FadeIn({
+  children,
+  delay = 0,
+  duration = 0.6,
+  y = 16,
+  once = true,
+  as = "div",
+  className,
+}: FadeInProps) {
+  const reduced = useReducedMotion();
+
+  if (reduced) {
+    const Static = as;
+    return <Static className={className}>{children}</Static>;
+  }
+
+  const Tag = MOTION_TAGS[as];
+
+  return (
+    <Tag
+      initial={{ opacity: 0, y }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once, margin: "-10%" }}
+      transition={{ duration, delay, ease: "easeOut" }}
+      className={className}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/components/ui/motion/HoverLift.tsx
+++ b/components/ui/motion/HoverLift.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import type { ReactNode } from "react";
+
+interface HoverLiftProps {
+  children: ReactNode;
+  /** ホバー時に持ち上がる Y 量 (px) */
+  lift?: number;
+  /** ホバー時のスケール (1.0 で変化なし) */
+  scale?: number;
+  className?: string;
+}
+
+/**
+ * カード等を hover で微妙に浮き上がらせるラッパー。
+ * prefers-reduced-motion: reduce ではアニメーション無効。
+ */
+export function HoverLift({
+  children,
+  lift = 4,
+  scale = 1.02,
+  className,
+}: HoverLiftProps) {
+  const reduced = useReducedMotion();
+
+  if (reduced) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <motion.div
+      className={className}
+      whileHover={{ y: -lift, scale }}
+      transition={{ type: "spring", stiffness: 300, damping: 25 }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/ui/motion/Parallax.tsx
+++ b/components/ui/motion/Parallax.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  motion,
+  useReducedMotion,
+  useScroll,
+  useTransform,
+} from "motion/react";
+import { useRef, type ReactNode } from "react";
+
+interface ParallaxProps {
+  children: ReactNode;
+  /**
+   * スクロールに対する追従の強さ。
+   * 正の値: 通常スクロールより遅く動く（背景レイヤー想定）
+   * 負の値: 逆方向に動く（前景の派手な動き想定）
+   * 0: パララックスなし
+   */
+  speed?: number;
+  className?: string;
+}
+
+/**
+ * 要素が viewport に入っている間、スクロール量に応じて Y 方向に変位させる。
+ * prefers-reduced-motion: reduce ではパララックスを無効化する。
+ */
+export function Parallax({ children, speed = 0.3, className }: ParallaxProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const reduced = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start end", "end start"],
+  });
+  // 0..1 の進行度を speed*100 % の translateY に変換
+  const y = useTransform(scrollYProgress, [0, 1], ["0%", `${speed * 100}%`]);
+
+  if (reduced) {
+    return (
+      <div ref={ref} className={className}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref} className={className}>
+      <motion.div style={{ y }}>{children}</motion.div>
+    </div>
+  );
+}

--- a/components/ui/motion/StaggerChildren.tsx
+++ b/components/ui/motion/StaggerChildren.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import type { ReactNode } from "react";
+
+interface StaggerChildrenProps {
+  children: ReactNode;
+  /** 子要素間の遅延 (秒) */
+  stagger?: number;
+  /** 子要素全体の開始遅延 (秒) */
+  delayChildren?: number;
+  /** 一度だけ発火するか */
+  once?: boolean;
+  className?: string;
+}
+
+/**
+ * 子要素 (<StaggerItem>) を一定間隔で順次フェードインさせるラッパー。
+ * prefers-reduced-motion: reduce では即時表示。
+ */
+export function StaggerChildren({
+  children,
+  stagger = 0.1,
+  delayChildren = 0,
+  once = true,
+  className,
+}: StaggerChildrenProps) {
+  const reduced = useReducedMotion();
+
+  if (reduced) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once, margin: "-10%" }}
+      variants={{
+        hidden: {},
+        visible: {
+          transition: {
+            staggerChildren: stagger,
+            delayChildren,
+          },
+        },
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+interface StaggerItemProps {
+  children: ReactNode;
+  /** 初期 Y オフセット (px) */
+  y?: number;
+  /** アニメーション尺 (秒) */
+  duration?: number;
+  className?: string;
+}
+
+/**
+ * StaggerChildren の子として使うアイテム。
+ * 親の variants に応じて hidden / visible を切り替える。
+ */
+export function StaggerItem({
+  children,
+  y = 16,
+  duration = 0.6,
+  className,
+}: StaggerItemProps) {
+  const reduced = useReducedMotion();
+
+  if (reduced) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <motion.div
+      className={className}
+      variants={{
+        hidden: { opacity: 0, y },
+        visible: {
+          opacity: 1,
+          y: 0,
+          transition: { duration, ease: "easeOut" },
+        },
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/ui/motion/index.ts
+++ b/components/ui/motion/index.ts
@@ -1,0 +1,4 @@
+export { FadeIn } from "./FadeIn";
+export { Parallax } from "./Parallax";
+export { StaggerChildren, StaggerItem } from "./StaggerChildren";
+export { HoverLift } from "./HoverLift";

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@supabase/supabase-js": "^2.105.1",
         "@tanstack/react-query": "^5.99.0",
         "heic-convert": "^2.1.0",
+        "motion": "^12.38.0",
         "next": "^16.2.3",
         "pg": "^8.20.0",
         "react": "^19.0.0",
@@ -5890,6 +5891,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -7724,6 +7752,47 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@supabase/supabase-js": "^2.105.1",
     "@tanstack/react-query": "^5.99.0",
     "heic-convert": "^2.1.0",
+    "motion": "^12.38.0",
     "next": "^16.2.3",
     "pg": "^8.20.0",
     "react": "^19.0.0",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
 
 // jsdom には ResizeObserver が存在しないため recharts の ResponsiveContainer が
 // エラーを出す。最小限のモックで解消する。
@@ -7,3 +8,33 @@ global.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 };
+
+// motion / useInView 等が使う IntersectionObserver の最小モック。
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+global.IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+// motion の useReducedMotion 等が使う matchMedia の最小モック。
+// 既定では reduce 指定なしとして返し、必要に応じてテスト側で上書きする。
+if (typeof window !== "undefined" && !window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}

--- a/tests/unit/components/motion/FadeIn.test.tsx
+++ b/tests/unit/components/motion/FadeIn.test.tsx
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// FadeIn プリミティブのユニットテスト
+//
+// アニメーション挙動そのものは jsdom で完結しないため、以下に絞って検証する:
+//   - children が DOM に出力される
+//   - as prop で指定したタグ要素でレンダリングされる
+//   - prefers-reduced-motion: reduce では静的タグ（motion なし）でレンダリングされる
+// ---------------------------------------------------------------------------
+
+import { render, screen } from "@testing-library/react";
+
+const useReducedMotionMock = vi.fn();
+
+vi.mock("motion/react", async () => {
+  const actual =
+    await vi.importActual<typeof import("motion/react")>("motion/react");
+  return {
+    ...actual,
+    useReducedMotion: () => useReducedMotionMock(),
+  };
+});
+
+import { FadeIn } from "@/components/ui/motion/FadeIn";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  useReducedMotionMock.mockReturnValue(false);
+});
+
+describe("FadeIn", () => {
+  it("children を DOM にレンダリングする", () => {
+    render(
+      <FadeIn>
+        <p>hello</p>
+      </FadeIn>,
+    );
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("デフォルトは div でラップされる", () => {
+    render(
+      <FadeIn>
+        <span data-testid="child">x</span>
+      </FadeIn>,
+    );
+    const child = screen.getByTestId("child");
+    expect(child.parentElement?.tagName.toLowerCase()).toBe("div");
+  });
+
+  it("as='section' で section タグでラップされる", () => {
+    render(
+      <FadeIn as="section">
+        <span data-testid="child">x</span>
+      </FadeIn>,
+    );
+    const child = screen.getByTestId("child");
+    expect(child.parentElement?.tagName.toLowerCase()).toBe("section");
+  });
+
+  it("className が外側要素に伝播する", () => {
+    render(
+      <FadeIn className="my-class">
+        <span data-testid="child">x</span>
+      </FadeIn>,
+    );
+    const child = screen.getByTestId("child");
+    expect(child.parentElement).toHaveClass("my-class");
+  });
+
+  it("prefers-reduced-motion: reduce のとき motion 属性無しでレンダリングされる", () => {
+    useReducedMotionMock.mockReturnValue(true);
+    render(
+      <FadeIn className="my-class">
+        <span data-testid="child">x</span>
+      </FadeIn>,
+    );
+    const wrapper = screen.getByTestId("child").parentElement!;
+    // motion で動かないことの確認: data-framer-* / style に opacity:0 が無い
+    expect(wrapper.getAttribute("style") ?? "").not.toContain("opacity");
+    expect(wrapper).toHaveClass("my-class");
+  });
+});

--- a/tests/unit/components/motion/HoverLift.test.tsx
+++ b/tests/unit/components/motion/HoverLift.test.tsx
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------------
+// HoverLift プリミティブのユニットテスト
+//
+// hover アニメ自体は jsdom で完結しないため、以下に絞って検証する:
+//   - children をレンダリングする
+//   - className が伝播する
+//   - reduced-motion 時に motion props 無しでレンダリングされる
+// ---------------------------------------------------------------------------
+
+import { render, screen } from "@testing-library/react";
+
+const useReducedMotionMock = vi.fn();
+
+vi.mock("motion/react", async () => {
+  const actual =
+    await vi.importActual<typeof import("motion/react")>("motion/react");
+  return {
+    ...actual,
+    useReducedMotion: () => useReducedMotionMock(),
+  };
+});
+
+import { HoverLift } from "@/components/ui/motion/HoverLift";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  useReducedMotionMock.mockReturnValue(false);
+});
+
+describe("HoverLift", () => {
+  it("children をレンダリングする", () => {
+    render(
+      <HoverLift>
+        <p>lift-me</p>
+      </HoverLift>,
+    );
+    expect(screen.getByText("lift-me")).toBeInTheDocument();
+  });
+
+  it("className が外側要素に伝播する", () => {
+    render(
+      <HoverLift className="card">
+        <span data-testid="child">x</span>
+      </HoverLift>,
+    );
+    expect(screen.getByTestId("child").parentElement).toHaveClass("card");
+  });
+
+  it("reduced-motion 時も children が表示され className が保持される", () => {
+    useReducedMotionMock.mockReturnValue(true);
+    render(
+      <HoverLift className="card">
+        <span data-testid="child">x</span>
+      </HoverLift>,
+    );
+    const wrapper = screen.getByTestId("child").parentElement!;
+    expect(wrapper).toHaveClass("card");
+  });
+});

--- a/tests/unit/components/motion/Parallax.test.tsx
+++ b/tests/unit/components/motion/Parallax.test.tsx
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+// Parallax プリミティブのユニットテスト
+//
+// scroll-linked transform は jsdom で完結しないため、以下に絞って検証する:
+//   - children が DOM に出力される
+//   - className が外側要素に伝播する
+//   - reduced-motion 時に motion ラッパーが除去される
+// ---------------------------------------------------------------------------
+
+import { render, screen } from "@testing-library/react";
+
+const useReducedMotionMock = vi.fn();
+
+vi.mock("motion/react", async () => {
+  const actual =
+    await vi.importActual<typeof import("motion/react")>("motion/react");
+  return {
+    ...actual,
+    useReducedMotion: () => useReducedMotionMock(),
+  };
+});
+
+import { Parallax } from "@/components/ui/motion/Parallax";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  useReducedMotionMock.mockReturnValue(false);
+});
+
+describe("Parallax", () => {
+  it("children を DOM にレンダリングする", () => {
+    render(
+      <Parallax>
+        <p>parallax-content</p>
+      </Parallax>,
+    );
+    expect(screen.getByText("parallax-content")).toBeInTheDocument();
+  });
+
+  it("className が外側コンテナに伝播する", () => {
+    render(
+      <Parallax className="wrap">
+        <span data-testid="child">x</span>
+      </Parallax>,
+    );
+    // wrap は外側、その中に motion.div（transform 用）、その中に children
+    const child = screen.getByTestId("child");
+    const motionWrap = child.parentElement!;
+    const outer = motionWrap.parentElement!;
+    expect(outer).toHaveClass("wrap");
+  });
+
+  it("reduced-motion 時は motion ラッパーが消える（child の親が outer 直下）", () => {
+    useReducedMotionMock.mockReturnValue(true);
+    render(
+      <Parallax className="wrap">
+        <span data-testid="child">x</span>
+      </Parallax>,
+    );
+    const child = screen.getByTestId("child");
+    expect(child.parentElement).toHaveClass("wrap");
+  });
+});

--- a/tests/unit/components/motion/StaggerChildren.test.tsx
+++ b/tests/unit/components/motion/StaggerChildren.test.tsx
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------
+// StaggerChildren / StaggerItem のユニットテスト
+// ---------------------------------------------------------------------------
+
+import { render, screen } from "@testing-library/react";
+
+const useReducedMotionMock = vi.fn();
+
+vi.mock("motion/react", async () => {
+  const actual =
+    await vi.importActual<typeof import("motion/react")>("motion/react");
+  return {
+    ...actual,
+    useReducedMotion: () => useReducedMotionMock(),
+  };
+});
+
+import {
+  StaggerChildren,
+  StaggerItem,
+} from "@/components/ui/motion/StaggerChildren";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  useReducedMotionMock.mockReturnValue(false);
+});
+
+describe("StaggerChildren", () => {
+  it("全ての子要素をレンダリングする", () => {
+    render(
+      <StaggerChildren>
+        <StaggerItem>
+          <p>one</p>
+        </StaggerItem>
+        <StaggerItem>
+          <p>two</p>
+        </StaggerItem>
+        <StaggerItem>
+          <p>three</p>
+        </StaggerItem>
+      </StaggerChildren>,
+    );
+    expect(screen.getByText("one")).toBeInTheDocument();
+    expect(screen.getByText("two")).toBeInTheDocument();
+    expect(screen.getByText("three")).toBeInTheDocument();
+  });
+
+  it("className が外側要素に伝播する", () => {
+    render(
+      <StaggerChildren className="grid">
+        <StaggerItem>
+          <span data-testid="item">x</span>
+        </StaggerItem>
+      </StaggerChildren>,
+    );
+    const item = screen.getByTestId("item");
+    const itemWrap = item.parentElement!;
+    const outer = itemWrap.parentElement!;
+    expect(outer).toHaveClass("grid");
+  });
+
+  it("reduced-motion 時も全ての子要素が表示される", () => {
+    useReducedMotionMock.mockReturnValue(true);
+    render(
+      <StaggerChildren>
+        <StaggerItem>
+          <p>a</p>
+        </StaggerItem>
+        <StaggerItem>
+          <p>b</p>
+        </StaggerItem>
+      </StaggerChildren>,
+    );
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("b")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 変更の概要
LP リデザインの基盤として、アニメーションライブラリ \`motion\` (v12) を導入し、再利用可能なプリミティブを実装する。

## 変更の理由
PR3 以降のトップ LP リデザインで、スクロール侵入アニメ・パララックス・ホバー演出を多用する。バラ書きを避けるため共通プリミティブを先に整備する。

## 変更内容
- 依存追加: \`motion@12.38.0\`
- プリミティブ実装:
  - \`<FadeIn>\` ビューポート侵入で fade + slide up
  - \`<Parallax>\` スクロールに連動した translateY 変位
  - \`<StaggerChildren>\` + \`<StaggerItem>\` 子要素を一定間隔で順次表示
  - \`<HoverLift>\` hover でカード等を微妙に浮き上がらせる
- 全プリミティブが \`prefers-reduced-motion: reduce\` を尊重（reduced 時はアニメ無効、children を即時表示）
- ファイル配置: \`components/ui/motion/\` 配下、\`index.ts\` で re-export
- テスト: 14 ケース（render と reduced-motion 挙動の検証）
- \`tests/setup.ts\` に motion 依存の IntersectionObserver / matchMedia の最小モック追加

## テスト方法
- \`npm test -- --run tests/unit/components/motion/\` 14/14 green
- \`npm test -- --run\` 545/545 green
- \`npm run typecheck\` / \`npm run lint\` / \`npm run build\` 全 pass

### 視覚的確認
jsdom ではアニメ本体が動かないため、見た目の検証はプリミティブを実利用する PR3 以降のスクリーンショットで担保する。本 PR は API 安定性と reduced-motion 挙動の担保のみが目的。

## 影響範囲
- 新規ライブラリ追加（motion ~30KB gzip）
- 既存コンポーネントには触らない（プリミティブ実利用は PR3 以降）

## チェックリスト
- [x] テストが完了している
- [x] コードレビューを依頼した
- [x] ドキュメントを更新した（必要に応じて）
- [x] コミットメッセージが適切である

Closes #61