### PR TITLE
feat: WebGL hero (D + shovel 3D) with lazy loading

### DIFF
--- a/app/(public)/_components/landing/HeroSection.tsx
+++ b/app/(public)/_components/landing/HeroSection.tsx
@@ -1,19 +1,24 @@
 import Link from "next/link";
 import { CalendarIcon, PlusIcon } from "@/components/ui/icons";
+import { HeroCanvasLazy } from "@/components/features/landing/HeroCanvasLazy";
 
 /**
- * トップ LP のヒーロー。後続 PR で WebGL シーンに差し替えるため、
- * 装飾領域は data-hero-canvas でマーキングしている。
+ * トップ LP のヒーロー。背景に WebGL シーン (D + シャベル 3D) を
+ * 重ねるが、CTA テキストの可読性のため WebGL レイヤは半透明オーバーレイ
+ * を間に挟む。
  */
 export function HeroSection() {
   return (
     <section className="relative isolate flex min-h-[calc(100svh-3.25rem)] flex-col items-center justify-center overflow-hidden bg-denim-dark px-6 py-24 text-center dark:bg-canvas">
-      {/* WebGL 差し替えターゲット。今は無地 */}
-      <div
-        data-hero-canvas
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10"
-      />
+      {/* WebGL レイヤ（dynamic + IO で遅延ロード、reduced-motion で完全 OFF） */}
+      <div data-hero-canvas className="absolute inset-0 -z-10">
+        <HeroCanvasLazy />
+        {/* CTA とコピーの読みやすさ確保のための薄いオーバーレイ */}
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-denim-dark/40 dark:bg-canvas/50"
+        />
+      </div>
 
       {/* 上部タグライン */}
       <p className="mb-6 inline-flex items-center gap-3 text-2xs font-medium tracking-[0.4em] text-offwhite/40 uppercase">

--- a/components/features/landing/HeroCanvas.tsx
+++ b/components/features/landing/HeroCanvas.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Canvas, useFrame } from "@react-three/fiber";
-import { useMemo, useRef } from "react";
+import type { MotionValue } from "motion/react";
+import { useEffect, useMemo, useRef } from "react";
 import * as THREE from "three";
 
 // ---------------------------------------------------------------------------
@@ -64,11 +65,15 @@ const EXTRUDE_SETTINGS: THREE.ExtrudeGeometryOptions = {
 };
 
 interface DigShovelMarkProps {
-  /** スクロール進行度 (0..1)。回転速度に微弱に反映する */
-  scrollProgress?: number;
+  /**
+   * スクロール進行度 (0..1) を保持する MotionValue。
+   * React state ではなく MotionValue 経由で受けることで、
+   * 親側の毎フレーム再レンダリングを回避する。
+   */
+  scrollProgress?: MotionValue<number>;
 }
 
-function DigShovelMark({ scrollProgress = 0 }: DigShovelMarkProps) {
+function DigShovelMark({ scrollProgress }: DigShovelMarkProps) {
   const groupRef = useRef<THREE.Group>(null);
 
   const dGeometry = useMemo(() => {
@@ -83,17 +88,26 @@ function DigShovelMark({ scrollProgress = 0 }: DigShovelMarkProps) {
     return geo;
   }, []);
 
-  useFrame((_, delta) => {
+  // R3F は JSX で attach された material は自動 dispose するが、
+  // useMemo + geometry prop 経由のインスタンスは管理外。明示的に解放する。
+  useEffect(() => {
+    return () => {
+      dGeometry.dispose();
+      shovelGeometry.dispose();
+    };
+  }, [dGeometry, shovelGeometry]);
+
+  useFrame((state, delta) => {
     if (!groupRef.current) return;
-    // 基本の自転 + スクロール進行で少しスピードアップ
-    groupRef.current.rotation.y += delta * (0.25 + scrollProgress * 0.4);
+    const sp = scrollProgress?.get() ?? 0;
+    groupRef.current.rotation.y += delta * (0.25 + sp * 0.4);
     groupRef.current.rotation.x =
-      Math.sin(performance.now() / 3500) * 0.08 + scrollProgress * 0.15;
+      Math.sin(state.clock.elapsedTime * 0.3) * 0.08 + sp * 0.15;
   });
 
   return (
     <group ref={groupRef}>
-      <mesh geometry={dGeometry} castShadow receiveShadow>
+      <mesh geometry={dGeometry}>
         <meshStandardMaterial
           color="#f8f4ed"
           metalness={0.15}
@@ -104,7 +118,6 @@ function DigShovelMark({ scrollProgress = 0 }: DigShovelMarkProps) {
         geometry={shovelGeometry}
         position={[0.05, -0.05, 0.18]}
         scale={[0.65, 0.65, 1]}
-        castShadow
       >
         <meshStandardMaterial
           color="#c0392b"
@@ -117,7 +130,7 @@ function DigShovelMark({ scrollProgress = 0 }: DigShovelMarkProps) {
 }
 
 interface HeroCanvasProps {
-  scrollProgress?: number;
+  scrollProgress?: MotionValue<number>;
 }
 
 /**
@@ -125,7 +138,7 @@ interface HeroCanvasProps {
  * 親 (HeroCanvasLazy) が IntersectionObserver と reduced-motion を見て
  * このコンポーネントの mount を制御する。
  */
-export function HeroCanvas({ scrollProgress = 0 }: HeroCanvasProps) {
+export function HeroCanvas({ scrollProgress }: HeroCanvasProps) {
   return (
     <Canvas
       camera={{ position: [0, 0, 3.6], fov: 42 }}

--- a/components/features/landing/HeroCanvas.tsx
+++ b/components/features/landing/HeroCanvas.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { Canvas, useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import * as THREE from "three";
+
+// ---------------------------------------------------------------------------
+// ジオメトリ生成: 「D」の輪郭を 2D Shape で定義し ExtrudeGeometry で押し出す。
+// 文字フォントの D を SVG パス相当でベジエ曲線で近似している。
+// ---------------------------------------------------------------------------
+function buildDShape(): THREE.Shape {
+  const shape = new THREE.Shape();
+
+  // 外形（左下から時計回り）
+  shape.moveTo(-0.55, -1);
+  shape.lineTo(0.1, -1);
+  shape.bezierCurveTo(0.95, -1, 1.3, -0.55, 1.3, 0);
+  shape.bezierCurveTo(1.3, 0.55, 0.95, 1, 0.1, 1);
+  shape.lineTo(-0.55, 1);
+  shape.lineTo(-0.55, -1);
+
+  // 内側（D のカウンター）を hole として
+  const hole = new THREE.Path();
+  hole.moveTo(-0.2, -0.65);
+  hole.lineTo(0.05, -0.65);
+  hole.bezierCurveTo(0.55, -0.65, 0.75, -0.35, 0.75, 0);
+  hole.bezierCurveTo(0.75, 0.35, 0.55, 0.65, 0.05, 0.65);
+  hole.lineTo(-0.2, 0.65);
+  hole.lineTo(-0.2, -0.65);
+  shape.holes.push(hole);
+
+  return shape;
+}
+
+// ---------------------------------------------------------------------------
+// シャベルの 2D 輪郭。柄（細い縦棒）+ ブレード（下向き台形 + 先端三角）。
+// D の前面に少し小さめに配置する想定で原点周りに収める。
+// ---------------------------------------------------------------------------
+function buildShovelShape(): THREE.Shape {
+  const shape = new THREE.Shape();
+
+  // 柄の上端中央から開始（時計回り）
+  shape.moveTo(-0.04, 0.95);
+  shape.lineTo(0.04, 0.95);
+  shape.lineTo(0.04, -0.1); // 柄の下端（ブレード境界）
+  shape.lineTo(0.22, -0.2); // ブレード右肩
+  shape.lineTo(0.18, -0.7); // ブレード右下
+  shape.lineTo(0, -0.95); // ブレード先端
+  shape.lineTo(-0.18, -0.7); // ブレード左下
+  shape.lineTo(-0.22, -0.2); // ブレード左肩
+  shape.lineTo(-0.04, -0.1); // 柄の下端
+  shape.lineTo(-0.04, 0.95);
+
+  return shape;
+}
+
+const EXTRUDE_SETTINGS: THREE.ExtrudeGeometryOptions = {
+  depth: 0.25,
+  bevelEnabled: true,
+  bevelThickness: 0.02,
+  bevelSize: 0.02,
+  bevelSegments: 2,
+  curveSegments: 24,
+};
+
+interface DigShovelMarkProps {
+  /** スクロール進行度 (0..1)。回転速度に微弱に反映する */
+  scrollProgress?: number;
+}
+
+function DigShovelMark({ scrollProgress = 0 }: DigShovelMarkProps) {
+  const groupRef = useRef<THREE.Group>(null);
+
+  const dGeometry = useMemo(() => {
+    const geo = new THREE.ExtrudeGeometry(buildDShape(), EXTRUDE_SETTINGS);
+    geo.center();
+    return geo;
+  }, []);
+
+  const shovelGeometry = useMemo(() => {
+    const geo = new THREE.ExtrudeGeometry(buildShovelShape(), EXTRUDE_SETTINGS);
+    geo.center();
+    return geo;
+  }, []);
+
+  useFrame((_, delta) => {
+    if (!groupRef.current) return;
+    // 基本の自転 + スクロール進行で少しスピードアップ
+    groupRef.current.rotation.y += delta * (0.25 + scrollProgress * 0.4);
+    groupRef.current.rotation.x =
+      Math.sin(performance.now() / 3500) * 0.08 + scrollProgress * 0.15;
+  });
+
+  return (
+    <group ref={groupRef}>
+      <mesh geometry={dGeometry} castShadow receiveShadow>
+        <meshStandardMaterial
+          color="#f8f4ed"
+          metalness={0.15}
+          roughness={0.55}
+        />
+      </mesh>
+      <mesh
+        geometry={shovelGeometry}
+        position={[0.05, -0.05, 0.18]}
+        scale={[0.65, 0.65, 1]}
+        castShadow
+      >
+        <meshStandardMaterial
+          color="#c0392b"
+          metalness={0.2}
+          roughness={0.45}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+interface HeroCanvasProps {
+  scrollProgress?: number;
+}
+
+/**
+ * トップ LP の HERO に重ねる 3D シーン。R3F で薄く包む。
+ * 親 (HeroCanvasLazy) が IntersectionObserver と reduced-motion を見て
+ * このコンポーネントの mount を制御する。
+ */
+export function HeroCanvas({ scrollProgress = 0 }: HeroCanvasProps) {
+  return (
+    <Canvas
+      camera={{ position: [0, 0, 3.6], fov: 42 }}
+      gl={{ antialias: true, alpha: true, powerPreference: "low-power" }}
+      dpr={[1, 1.5]}
+    >
+      <ambientLight intensity={0.35} color="#f8f4ed" />
+      <directionalLight position={[3, 4, 5]} intensity={1.1} color="#f8f4ed" />
+      <directionalLight
+        position={[-4, -2, -3]}
+        intensity={0.5}
+        color="#4a6fa5"
+      />
+      <DigShovelMark scrollProgress={scrollProgress} />
+    </Canvas>
+  );
+}

--- a/components/features/landing/HeroCanvasLazy.tsx
+++ b/components/features/landing/HeroCanvasLazy.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useReducedMotion, useScroll, useTransform } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+
+// three.js を初期バンドルから完全に除外するため dynamic import で SSR スキップ
+const HeroCanvas = dynamic(
+  () => import("./HeroCanvas").then((m) => ({ default: m.HeroCanvas })),
+  { ssr: false },
+);
+
+/**
+ * HeroCanvas の遅延ロード wrapper。
+ *
+ * - prefers-reduced-motion: reduce なら一切ロードしない（CO2/Perf/UX）
+ * - IntersectionObserver でビューポート侵入後にだけ dynamic import を起動
+ * - スクロール進行度を子に渡してカメラ/オブジェクトに反映させる
+ * - aria-hidden=true で純装飾扱い、HERO 内の CTA/テキストの読み上げを阻害しない
+ */
+export function HeroCanvasLazy() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shouldRender, setShouldRender] = useState(false);
+  const reduced = useReducedMotion();
+
+  // セクション基準のスクロール進行度。reduced-motion 時は購読しても
+  // 子で使わないので副作用は無視できる。
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start end", "end start"],
+  });
+  const progress = useTransform(scrollYProgress, [0, 1], [0, 1]);
+  const [progressValue, setProgressValue] = useState(0);
+
+  useEffect(() => {
+    if (reduced) return;
+    return progress.on("change", (v) => setProgressValue(v));
+  }, [progress, reduced]);
+
+  useEffect(() => {
+    if (reduced) return;
+    const target = ref.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry?.isIntersecting) {
+          setShouldRender(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [reduced]);
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0"
+    >
+      {shouldRender && <HeroCanvas scrollProgress={progressValue} />}
+    </div>
+  );
+}

--- a/components/features/landing/HeroCanvasLazy.tsx
+++ b/components/features/landing/HeroCanvasLazy.tsx
@@ -15,27 +15,26 @@ const HeroCanvas = dynamic(
  *
  * - prefers-reduced-motion: reduce なら一切ロードしない（CO2/Perf/UX）
  * - IntersectionObserver でビューポート侵入後にだけ dynamic import を起動
- * - スクロール進行度を子に渡してカメラ/オブジェクトに反映させる
+ * - スクロール進行度を MotionValue として子に渡す。React state を介すと
+ *   毎フレーム再レンダリングで Canvas が reconcile されるため、ref 経由で
+ *   購読する設計にする
  * - aria-hidden=true で純装飾扱い、HERO 内の CTA/テキストの読み上げを阻害しない
+ *
+ * 注: useScroll の target は本コンポーネントの wrapper を指す。wrapper は
+ * 親 HeroSection に対して absolute inset-0 で覆われているため、実質的に
+ * セクション基準の進行度として機能する。
  */
 export function HeroCanvasLazy() {
   const ref = useRef<HTMLDivElement>(null);
   const [shouldRender, setShouldRender] = useState(false);
   const reduced = useReducedMotion();
 
-  // セクション基準のスクロール進行度。reduced-motion 時は購読しても
-  // 子で使わないので副作用は無視できる。
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ["start end", "end start"],
   });
+  // MotionValue のまま子へ渡す（state 化しない）
   const progress = useTransform(scrollYProgress, [0, 1], [0, 1]);
-  const [progressValue, setProgressValue] = useState(0);
-
-  useEffect(() => {
-    if (reduced) return;
-    return progress.on("change", (v) => setProgressValue(v));
-  }, [progress, reduced]);
 
   useEffect(() => {
     if (reduced) return;
@@ -62,7 +61,7 @@ export function HeroCanvasLazy() {
       aria-hidden="true"
       className="pointer-events-none absolute inset-0"
     >
-      {shouldRender && <HeroCanvas scrollProgress={progressValue} />}
+      {shouldRender && !reduced && <HeroCanvas scrollProgress={progress} />}
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@google/generative-ai": "^0.24.1",
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "@supabase/supabase-js": "^2.105.1",
         "@tanstack/react-query": "^5.99.0",
         "heic-convert": "^2.1.0",
@@ -23,6 +25,7 @@
         "react-dom": "^19.0.0",
         "recharts": "^2.15.3",
         "sharp": "^0.34.5",
+        "three": "^0.184.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -38,6 +41,7 @@
         "@types/react-dom": "^19",
         "@types/sharp": "^0.31.1",
         "@types/testing-library__jest-dom": "^5.14.9",
+        "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9",
         "eslint-config-next": "^16.2.3",
@@ -551,6 +555,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite": {
       "version": "0.4.1",
@@ -1452,6 +1462,24 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2060,6 +2088,94 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
           "optional": true
         }
       }
@@ -2859,6 +2975,12 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2956,6 +3078,12 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3061,6 +3189,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
@@ -3076,7 +3210,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3090,6 +3223,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/sharp": {
@@ -3109,6 +3251,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
@@ -3118,6 +3266,26 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3696,6 +3864,24 @@
         "win32"
       ]
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -4158,6 +4344,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
@@ -4181,7 +4387,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -4243,6 +4448,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/c12": {
@@ -4332,6 +4561,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4502,11 +4744,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4858,6 +5117,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4909,6 +5177,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5794,6 +6068,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6149,6 +6429,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6320,6 +6606,12 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/hono": {
       "version": "4.12.12",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
@@ -6376,6 +6668,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6385,6 +6697,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -6711,6 +7029,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -6874,7 +7198,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -6893,6 +7216,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jest-diff": {
@@ -7324,6 +7659,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -7669,6 +8013,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7705,6 +8059,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -8273,7 +8642,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8562,6 +8930,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8639,6 +9013,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prop-types": {
@@ -8788,6 +9172,21 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -8912,7 +9311,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9244,7 +9642,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9257,7 +9654,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9432,6 +9828,32 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {
@@ -9653,6 +10075,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -9680,6 +10111,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -9821,6 +10290,36 @@
         "node": ">=20"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -9873,6 +10372,43 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10112,6 +10648,24 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/valibot": {
@@ -10395,6 +10949,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -10434,7 +10999,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10660,6 +11224,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@google/generative-ai": "^0.24.1",
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@supabase/supabase-js": "^2.105.1",
     "@tanstack/react-query": "^5.99.0",
     "heic-convert": "^2.1.0",
@@ -28,6 +30,7 @@
     "react-dom": "^19.0.0",
     "recharts": "^2.15.3",
     "sharp": "^0.34.5",
+    "three": "^0.184.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -43,6 +46,7 @@
     "@types/react-dom": "^19",
     "@types/sharp": "^0.31.1",
     "@types/testing-library__jest-dom": "^5.14.9",
+    "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9",
     "eslint-config-next": "^16.2.3",

--- a/tests/unit/components/features/landing/HeroCanvasLazy.test.tsx
+++ b/tests/unit/components/features/landing/HeroCanvasLazy.test.tsx
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------
+// HeroCanvasLazy のユニットテスト
+//
+// three.js / R3F 本体は jsdom で WebGL context が無いため動かせない。
+// 本テストでは lazy ラッパーの振る舞いに絞って検証する:
+//   - aria-hidden="true" が wrapper に付与される（純装飾扱い）
+//   - prefers-reduced-motion: reduce のときは HeroCanvas を一切 mount しない
+//   - 通常時は IntersectionObserver 監視結果を経るまで HeroCanvas を mount しない
+// ---------------------------------------------------------------------------
+
+import { render } from "@testing-library/react";
+
+const useReducedMotionMock = vi.fn();
+
+vi.mock("motion/react", async () => {
+  const actual =
+    await vi.importActual<typeof import("motion/react")>("motion/react");
+  return {
+    ...actual,
+    useReducedMotion: () => useReducedMotionMock(),
+  };
+});
+
+// next/dynamic を「常に null を返す」ダミーコンポーネントに差し替えて、
+// three.js 本体のロードを完全に避ける。これにより jsdom で WebGL が
+// 評価されることもない。
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    const Dummy = () => null;
+    Dummy.displayName = "HeroCanvasDynamicStub";
+    return Dummy;
+  },
+}));
+
+import { HeroCanvasLazy } from "@/components/features/landing/HeroCanvasLazy";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  useReducedMotionMock.mockReturnValue(false);
+});
+
+describe("HeroCanvasLazy", () => {
+  it("wrapper は aria-hidden='true' で純装飾扱いされる", () => {
+    const { container } = render(<HeroCanvasLazy />);
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("初期描画では HeroCanvas は mount されない（IO 検知前）", () => {
+    const { container } = render(<HeroCanvasLazy />);
+    const wrapper = container.firstElementChild;
+    // dynamic も null を返すスタブにしているので、wrapper は children を持たない
+    expect(wrapper?.childNodes.length).toBe(0);
+  });
+
+  it("reduced-motion 時も HeroCanvas は mount されない", () => {
+    useReducedMotionMock.mockReturnValue(true);
+    const { container } = render(<HeroCanvasLazy />);
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.childNodes.length).toBe(0);
+  });
+});

--- a/tests/unit/components/features/landing/HeroCanvasLazy.test.tsx
+++ b/tests/unit/components/features/landing/HeroCanvasLazy.test.tsx
@@ -60,3 +60,54 @@ describe("HeroCanvasLazy", () => {
     expect(wrapper?.childNodes.length).toBe(0);
   });
 });
+
+describe("HeroCanvasLazy — IntersectionObserver ライフサイクル", () => {
+  const origIO = global.IntersectionObserver;
+  let ctorSpy: ReturnType<typeof vi.fn<() => void>>;
+  let observeSpy: ReturnType<typeof vi.fn<() => void>>;
+  let disconnectSpy: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    ctorSpy = vi.fn();
+    observeSpy = vi.fn();
+    disconnectSpy = vi.fn();
+
+    class SpyIO {
+      observe = observeSpy;
+      disconnect = disconnectSpy;
+      unobserve = vi.fn();
+      takeRecords() {
+        return [];
+      }
+      constructor() {
+        ctorSpy();
+      }
+    }
+    global.IntersectionObserver =
+      SpyIO as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    global.IntersectionObserver = origIO;
+  });
+
+  it("通常時は IntersectionObserver が生成され observe が呼ばれる", () => {
+    render(<HeroCanvasLazy />);
+    expect(ctorSpy).toHaveBeenCalledTimes(1);
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("unmount 時に observer.disconnect() が呼ばれる（リーク防止）", () => {
+    const { unmount } = render(<HeroCanvasLazy />);
+    expect(disconnectSpy).not.toHaveBeenCalled();
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reduced-motion 時は IntersectionObserver を生成しない", () => {
+    useReducedMotionMock.mockReturnValue(true);
+    render(<HeroCanvasLazy />);
+    expect(ctorSpy).not.toHaveBeenCalled();
+    expect(observeSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 変更の概要
トップ LP の HERO セクションに、ブランドシンボル「D + シャベル」をポリゴンで表現する WebGL シーンを追加する。three.js は完全に初期バンドル外に出し、Lighthouse Performance 70+ を維持する設計。

## 変更の理由
- LP のブランド体験を強化するためヒーローを 3D 化（マスター要求の "WebGL/Three.js 3D グラフィックス使用"）
- ただし全画面に WebGL を入れると LCP が崩壊するので、HERO 単発に限定 + 完全 dynamic 化で初期バンドルは静的 LP と同等を維持

## 変更内容
### 依存追加
- \`three@0.184\`
- \`@react-three/fiber@9.6\`
- \`@react-three/drei@10.7\`
- \`@types/three\` (dev)

### 実装
- \`components/features/landing/HeroCanvas.tsx\`
  - \`THREE.Shape\` + \`ExtrudeGeometry\` で D（外形 + カウンター hole）とシャベル（柄 + ブレード）を 2D 輪郭から 3D ポリゴン化
  - group をゆっくり自転 + sin で微弱 Y 振り
  - スクロール進行度を rotation 速度と X 軸傾きに反映
  - ライティング: ambient + directional × 2（offwhite キー + denim-light フィル）
  - \`gl: powerPreference: "low-power"\` / \`dpr: [1, 1.5]\` で SP の負荷を抑制
- \`components/features/landing/HeroCanvasLazy.tsx\`
  - \`next/dynamic({ ssr: false })\` で three.js を初期バンドル外へ
  - \`IntersectionObserver\` でビューポート侵入後にのみ HeroCanvas を mount
  - \`useReducedMotion\` で reduced-motion 時は IO 監視ごとスキップ（完全 OFF）
  - motion の \`useScroll\` + \`useTransform\` でスクロール進行度を child に伝搬
- \`app/(public)/_components/landing/HeroSection.tsx\` に \`HeroCanvasLazy\` を統合、CTA 可読性のため半透明オーバーレイを間に挿入

### テスト
\`tests/unit/components/features/landing/HeroCanvasLazy.test.tsx\`（3 件）
- aria-hidden が wrapper に付与される
- 初期描画では HeroCanvas が mount されない（IO 検知前）
- reduced-motion 時も HeroCanvas が mount されない

WebGL 本体は jsdom で動かない（Canvas/WebGL context 無し）ので、\`next/dynamic\` をスタブ化して mount 制御のみ検証する方針。視覚クオリティは reviewer のローカル確認で担保。

## テスト方法
- \`npm test -- --run\` 548/548 green
- \`npm run typecheck\` / \`npm run lint\` / \`npm run build\` 全 pass
- \`/\` ルートは依然 \`○ (Static)\` のままで build 出力 — three.js が初期バンドル外であることの間接確認

### 視覚的確認（reviewer 用）
- \`npm run dev\` → \`/\` を開く
- HERO 背景に D + 赤いシャベルがゆっくり自転すること
- スクロールに合わせて回転速度が微妙に上がること
- DevTools の Application > Service Workers / Network で初回ロード時に three 系チャンクが入っていない（HERO が画面内に入った瞬間にロードされる）
- DevTools で \`prefers-reduced-motion: reduce\` をシミュレートすると WebGL が一切ロードされない
- SP (390px) / PC (1280px) で HERO 内 CTA が WebGL の裏に隠れず読めること

## 影響範囲
- トップ \`/\` の HERO のみ。他ルートに変更なし
- バンドル: 初期は影響なし（dynamic）、HERO 表示時に three.js 系 ~180KB gzip がロードされる
- LP リデザインの段階的展開のうち PR4 にあたる（前: #59 PR1, #61 PR2, #63 PR3 / 後: PR5 演出仕上げ, PR6 機能ページ）

## チェックリスト
- [x] テストが完了している
- [x] コードレビューを依頼した
- [x] ドキュメントを更新した（必要に応じて）
- [x] コミットメッセージが適切である

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ランディングページのヒーロー背景に3D WebGLアニメーション層を追加
  * スクロール連動のアニメーション機能を実装
  * 画像の遅延読み込みによりパフォーマンスを向上
  * 動きの軽減設定に対応（アクセシビリティ向上）

* **テスト**
  * 新機能に対応するユニットテストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fune6900/DIG/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->