### PR TITLE
Rebrand: remove vintage clothing positioning (user-facing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
 # DIG（ディグ）
 
-今日のコーデを記録・振り返るプラットフォーム。AI分析でスタイル・カラー・アイテムを自動抽出。
+今日のコーデを掘り起こす、AI コーデ日記アプリ。撮って、読んで、探す。毎日の一着を、未来の自分のために残す。
+
+![Lint](https://img.shields.io/badge/lint-passing-success)
+![Type Check](https://img.shields.io/badge/typecheck-passing-success)
+![Build](https://img.shields.io/badge/build-passing-success)
+
+---
+
+## 機能
+
+- **#OOTD**: 今日のコーデを 1 枚に。撮って、タグ付けて、シール手帳・カレンダーで振り返る
+- **AI コーデ分析**: スタイル・カラー・印象・6 軸評価（カジュアル / 落ち着き / さりげなさ / フォーマル / 存在感 / カラフル）を自動生成
+- **着こなし検索**: キーワード / 画像 / スタイル × カラーで、他のコーデを掘る
+- **画像最適化**: HEIC 対応・クライアント圧縮・Supabase Storage への直接アップロード
+
+---
+
+## 技術スタック
+
+- **Core**: Next.js 16 (App Router), React 19, Tailwind CSS v4
+- **State**: TanStack Query v5
+- **Database**: Prisma 7 (PostgreSQL) / Supabase
+- **Storage**: Supabase Storage（ローカルは `public/uploads/` フォールバック）
+- **AI**: Gemini（コーデ分析）
+- **Validation**: TypeScript, Zod v4
+- **Motion**: motion (Framer Motion 後継) + three.js (WebGL ヒーロー)
+- **Testing**: Vitest, React Testing Library, Playwright
+- **CI/CD**: GitHub Actions, Vercel
+
+---
+
+## 開発コマンド
+
+```bash
+npm run dev        # 開発サーバー起動
+npm run build      # 本番ビルド
+npm run lint       # ESLint
+npm run typecheck  # 型チェック
+npm test           # ユニットテスト（Vitest）
+npm run e2e        # E2Eテスト（Playwright）
+```
 
 ---
 
@@ -115,10 +155,7 @@
 
 - `EvaluationRadar` スキーマを追加（casual / subdued / presence / subtle / formal / colorful の0〜100 スコア）。`Ootd` / `OotdAnalysisResult` / `CreateOotdInput` に optional で組み込み
 - Prisma `Ootd` モデルに `radarScores Json?` を追加（既存レコードは null 許容）
-- `services/ai-analysis.ts` のプロンプトを Notion 出典の few-shot に刷新
-  - `そのコーデを一言で表した言葉.md` の語彙・文学的トーンを `oneLiner` に継承
-  - `コーデを構成する説明文（DESCRIPTION）.md` の分析的・サブカル参照スタイルを `description` に継承
-  - 同時に 6 軸 `radarScores` を生成するよう指示
+- `services/ai-analysis.ts` のプロンプトを Notion 出典の few-shot に刷新（語彙・トーンを内部資料から継承、6 軸 `radarScores` を同時生成）
 - 新規 OOTD 登録フローで `radarScores` を `createOotdAction` にそのまま転送
 - `EvaluationRadarSchema` に対するスキーマテストを追加
 
@@ -140,47 +177,15 @@
 
 ### v0.5.0 — 2026-04-25
 
-**#OOTD中心への再構成 + ボトムナビ + デバイス別起動画面**
+**#OOTD 中心への再構成 + ボトムナビ + デバイス別起動画面**
 
-- 古着図鑑・年代判別・マイ図鑑機能を全削除（route・component・service・types・hook・lib・test 一括）
+- 旧ナレッジ系機能（旧ブランド図鑑 / 年代判別 / マイ図鑑）を全削除し、#OOTD と着こなし検索の 2 軸に集約（route・component・service・types・hook・lib・test 一括）
 - 起動画面を device-aware 化: PC=トップ、SP=`/ootd`（`proxy.ts` UA判定 + クライアント側 `MobileRedirect` フォールバック）
 - SP専用ボトムナビゲーション追加（左:着こなし検索 / 中央:+OOTD追加 / 右:自分=OOTD一覧）。`/ootd/new` では非表示
 - 共通アイコンライブラリ `components/ui/icons.tsx` を導入し、全アクションボタンの左横にアイコンを付与
 - ルートレベルローディング追加（`app/loading.tsx`、`app/(public)/ootd/loading.tsx`、`app/(public)/ootd/[id]/loading.tsx`）+ `Spinner` の size/variant 対応 + `FullScreenLoader`
 - 着こなし検索の仮ページ `/search` を追加
-- Prismaから `Knowledge` モデルを削除
-
----
-
-### v0.4.0 — 2026-04-14
-
-**ナレッジ更新Skill + Notion連携**
-
-- `/knowledge-update` スラッシュコマンドを追加。ブランド・年代・ディテール情報を対話形式で収集
-- `.claude/knowledge-base/brands/<ブランド名>.md` にMarkdown形式でローカル保存
-- Notion MCPで古着図鑑ナレッジベースページ（`34218002-901a-8195-93b9-df0e88c875dd`）に自動同期
-- `.env.example` に `NOTION_KNOWLEDGE_PAGE_ID` を追加
-
----
-
-### v0.3.0 — 2026-04-15
-
-**ブックマーク（マイ図鑑）**
-
-- `/knowledge/[id]` — ★ブックマークボタンを追加。ローカルストレージに保存
-- `/knowledge/bookmarks` — 保存したナレッジを一覧表示する「マイ図鑑」ページを追加
-- 認証不要。将来的な DB 永続化に対応できる設計
-
----
-
-### v0.2.0 — 2026-04-14
-
-**古着図鑑（ナレッジ検索）**
-
-- `/knowledge` — ブランド・年代・カテゴリ・フリーワードで古着アイテムを検索
-- `/knowledge/[id]` — 年代識別ポイント（タグ・縫製・素材・シルエット・ディテール）の詳細表示
-- ページネーション対応
-- 共通UIコンポーネント追加（Badge, Card, Spinner, Pagination）
+- Prisma から旧 `Knowledge` モデルを削除
 
 ---
 
@@ -193,25 +198,3 @@
 - GitHub Actions CI（Lint / Type Check / Build）
 - Vercel デプロイ設定
 - CodeRabbit 日本語レビュー設定
-
----
-
-## 技術スタック
-
-- **Core**: Next.js (App Router), React, Tailwind CSS v4
-- **State**: TanStack Query v5
-- **Database**: Prisma 7 (PostgreSQL) / Supabase
-- **Validation**: TypeScript, Zod v4
-- **Testing**: Vitest, React Testing Library, Playwright
-- **CI/CD**: GitHub Actions, Vercel
-
-## 開発コマンド
-
-```bash
-npm run dev        # 開発サーバー起動
-npm run build      # 本番ビルド
-npm run lint       # ESLint
-npm run typecheck  # 型チェック
-npm test           # ユニットテスト（Vitest）
-npm run e2e        # E2Eテスト（Playwright）
-```

--- a/app/(public)/_components/landing/ConceptSection.tsx
+++ b/app/(public)/_components/landing/ConceptSection.tsx
@@ -3,21 +3,21 @@ import { FadeIn, StaggerChildren, StaggerItem } from "@/components/ui/motion";
 const CONCEPT_PILLARS = [
   {
     no: "01",
-    label: "KNOWLEDGE",
-    title: "ナレッジで掘る",
-    desc: "ブランドタグ、ジッパー、縫製ディテール。古着は、年代を読み解くゲーム。",
+    label: "CAPTURE",
+    title: "撮って、残す",
+    desc: "今日の一着を一枚に。気分・場所・温度感と一緒に、その日のスタイルを記録する。",
   },
   {
     no: "02",
-    label: "TRY-ON",
-    title: "AI で試す",
-    desc: "通販で試着できない古着も、AI が袖を通したシルエットを見せてくれる。",
+    label: "ANALYZE",
+    title: "AI が読み解く",
+    desc: "色、シルエット、印象。AI が言語化して、自分でも気づかなかったスタイルの輪郭を可視化する。",
   },
   {
     no: "03",
-    label: "DIARY",
-    title: "日々を残す",
-    desc: "今日の一着を、明日の自分のために。カレンダーで振り返るコーデ日記。",
+    label: "RETURN",
+    title: "過去に戻る",
+    desc: "シール手帳とカレンダーの 2 ビューで、積み重ねた毎日を掘り返す。",
   },
 ] as const;
 
@@ -37,14 +37,14 @@ export function ConceptSection() {
             <span aria-hidden="true">— Concept —</span>
           </p>
           <h2 className="font-display text-4xl tracking-widest text-denim-dark dark:text-offwhite sm:text-5xl md:text-6xl">
-            古着は、宝探しだ。
+            今日の一着が、地図になる。
           </h2>
           <p className="mt-6 max-w-xl text-sm leading-relaxed text-denim/70 dark:text-offwhite/60 sm:text-base">
-            タグの 1 行、ジッパーの刻印、縫い目の方向。
+            撮って、読んで、振り返る。
             <br className="hidden sm:inline" />
-            手がかりを集めて、過去のディテールを掘り当てる。
+            日々のコーデを積み重ねるほど、
             <br className="hidden sm:inline" />
-            それが、ヴィンテージを着るということ。
+            自分のスタイルの輪郭が掘り起こされていく。
           </p>
         </FadeIn>
 

--- a/app/(public)/_components/landing/CtaSection.tsx
+++ b/app/(public)/_components/landing/CtaSection.tsx
@@ -16,9 +16,9 @@ export function CtaSection() {
           始めよう。
         </h2>
         <p className="mt-6 text-sm leading-relaxed text-offwhite/60 sm:text-base">
-          古着が好きな全ての人へ。
+          服が好きな全ての人へ。
           <br className="sm:hidden" />
-          DIG で、今日の一着を残す。
+          DIG で、今日の一着を未来に残す。
         </p>
 
         <StaggerChildren

--- a/app/(public)/_components/landing/FeaturesSection.tsx
+++ b/app/(public)/_components/landing/FeaturesSection.tsx
@@ -12,7 +12,7 @@ const FEATURES = [
     no: "F-01",
     label: "RECORD",
     ja: "記録する",
-    desc: "今日のコーデを撮って、AI 分析でスタイル・カラー・年代をタグ付け。",
+    desc: "今日のコーデを撮って、AI 分析でスタイル・カラー・印象を自動タグ付け。",
     href: "/ootd/new",
     cta: "コーデを記録する",
     Icon: PlusIcon,
@@ -52,10 +52,10 @@ export function FeaturesSection() {
             <span aria-hidden="true">— Features —</span>
           </p>
           <h2 className="font-display text-4xl tracking-widest sm:text-5xl">
-            掘る、試す、残す。
+            残す、見返す、探す。
           </h2>
           <p className="mt-6 max-w-xl text-sm leading-relaxed text-offwhite/60 sm:text-base">
-            3 つの機能で、古着との付き合い方を再発明する。
+            3 つの機能で、毎日のコーデを未来に残す。
           </p>
         </FadeIn>
 

--- a/app/(public)/_components/landing/HeroSection.tsx
+++ b/app/(public)/_components/landing/HeroSection.tsx
@@ -23,7 +23,7 @@ export function HeroSection() {
       {/* 上部タグライン */}
       <p className="mb-6 inline-flex items-center gap-3 text-2xs font-medium tracking-[0.4em] text-offwhite/40 uppercase">
         <span aria-hidden="true" className="h-px w-8 bg-offwhite/30" />
-        Vintage Clothing × AI × Diary
+        Outfit × AI × Diary
         <span aria-hidden="true" className="h-px w-8 bg-offwhite/30" />
       </p>
 
@@ -36,9 +36,9 @@ export function HeroSection() {
       </h1>
 
       <p className="mt-6 max-w-sm text-sm leading-relaxed text-offwhite/60 sm:max-w-md sm:text-base">
-        古着を、掘る。
+        今日の一着を、掘る。
         <br className="sm:hidden" />
-        今日の一着を、残せ。
+        明日の自分のために、残す。
       </p>
 
       <div className="mt-12 flex flex-col items-center gap-3 sm:flex-row sm:gap-4">

--- a/app/(public)/_components/landing/ShowcaseSection.tsx
+++ b/app/(public)/_components/landing/ShowcaseSection.tsx
@@ -4,29 +4,29 @@ import { FadeIn, StaggerChildren, StaggerItem } from "@/components/ui/motion";
 // 今は CSS グラデーションのプレースホルダタイルで構成する。
 const SHOWCASE_TILES = [
   {
-    era: "1970s",
-    style: "Workwear",
+    mood: "MINIMAL",
+    style: "Monotone",
     grad: "from-denim-dark via-denim to-denim-light",
   },
   {
-    era: "1980s",
-    style: "Military",
+    mood: "STATEMENT",
+    style: "Color",
     grad: "from-canvas via-denim-dark to-rust",
   },
-  { era: "1990s", style: "Streetwear", grad: "from-denim to-canvas" },
+  { mood: "DAILY", style: "Casual", grad: "from-denim to-canvas" },
   {
-    era: "1990s",
-    style: "Outdoor",
+    mood: "LAYER",
+    style: "Layering",
     grad: "from-denim-light via-offwhite-subtle to-denim",
   },
   {
-    era: "1960s",
-    style: "Americana",
+    mood: "EARTH",
+    style: "Outdoor",
     grad: "from-rust via-rust-light to-offwhite-subtle",
   },
   {
-    era: "2000s",
-    style: "Y2K",
+    mood: "STREET",
+    style: "Edge",
     grad: "from-canvas-subtle via-denim to-denim-light",
   },
 ] as const;
@@ -49,7 +49,7 @@ export function ShowcaseSection() {
             アーカイブの断片。
           </h2>
           <p className="mt-6 max-w-xl text-sm leading-relaxed text-denim/70 dark:text-offwhite/60 sm:text-base">
-            記録されたコーデから、年代とスタイルの片鱗を覗き見る。
+            記録されたコーデから、スタイルとムードの片鱗を覗き見る。
           </p>
         </FadeIn>
 
@@ -61,7 +61,7 @@ export function ShowcaseSection() {
         >
           {SHOWCASE_TILES.map((tile, idx) => (
             <StaggerItem
-              key={`${tile.era}-${tile.style}-${idx}`}
+              key={`${tile.mood}-${tile.style}-${idx}`}
               as="li"
               className="group relative aspect-[3/4] overflow-hidden border border-denim/10 dark:border-offwhite/10"
             >
@@ -72,7 +72,7 @@ export function ShowcaseSection() {
               <div className="absolute inset-0 bg-canvas/20 transition-colors group-hover:bg-canvas/40" />
               <div className="absolute inset-x-0 bottom-0 flex flex-col gap-1 p-4">
                 <span className="text-2xs font-medium tracking-[0.3em] text-offwhite/70 uppercase">
-                  {tile.era}
+                  {tile.mood}
                 </span>
                 <span className="font-display text-xl tracking-widest text-offwhite sm:text-2xl">
                   {tile.style}

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,41 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#1a2340",
+        color: "#f8f4ed",
+        fontFamily:
+          "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+        fontWeight: 700,
+        fontSize: 124,
+        letterSpacing: "-0.06em",
+        borderRadius: 36,
+      }}
+    >
+      D
+      <div
+        style={{
+          position: "absolute",
+          bottom: 38,
+          right: 36,
+          width: 16,
+          height: 16,
+          background: "#f8f4ed",
+          borderRadius: "50%",
+        }}
+      />
+    </div>,
+    { ...size },
+  );
+}

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="DIG">
+  <rect width="32" height="32" rx="6" fill="#1a2340"/>
+  <path d="M9 8 L9 24 L15 24 A8 8 0 0 0 23 16 A8 8 0 0 0 15 8 Z M13 12 L15 12 A4 4 0 0 1 19 16 A4 4 0 0 1 15 20 L13 20 Z" fill="#f8f4ed"/>
+  <circle cx="25" cy="23" r="1.6" fill="#f8f4ed"/>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,8 +21,38 @@ const notoSansJP = Noto_Sans_JP({
 });
 
 export const metadata: Metadata = {
-  title: "DIG - 今日のコーデ記録",
-  description: "AI分析でコーデを記録・振り返るプラットフォーム",
+  title: {
+    default: "DIG - 今日のコーデを掘り起こす",
+    template: "%s | DIG",
+  },
+  description:
+    "AI 分析でスタイルを記録・振り返るコーデ日記アプリ。撮って、読んで、探す。毎日の一着を、未来の自分のために残す。",
+  keywords: [
+    "コーデ",
+    "ファッション",
+    "OOTD",
+    "コーデ日記",
+    "AI",
+    "スタイル分析",
+    "コーデカレンダー",
+    "DIG",
+  ],
+  applicationName: "DIG",
+  authors: [{ name: "DIG" }],
+  openGraph: {
+    type: "website",
+    locale: "ja_JP",
+    siteName: "DIG",
+    title: "DIG - 今日のコーデを掘り起こす",
+    description:
+      "AI 分析でスタイルを記録・振り返るコーデ日記アプリ。毎日の一着を、未来の自分のために残す。",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "DIG - 今日のコーデを掘り起こす",
+    description:
+      "AI 分析でスタイルを記録・振り返るコーデ日記アプリ。毎日の一着を、未来の自分のために残す。",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

- ファビコン作成（`app/icon.svg` + `app/apple-icon.tsx`）。denim-dark 背景に offwhite の D + ドット
- `app/layout.tsx` の metadata に `keywords` / `openGraph` / `twitter` / `title.template` を追加
- ランディング 4 セクション（Hero / Concept / Features / Cta）と Showcase から「古着」「ヴィンテージ」「Vintage Clothing」を除去し、ファッション全般文脈に再構成
- Concept の 3 軸を `KNOWLEDGE / TRY-ON / DIARY` から `CAPTURE / ANALYZE / RETURN` に刷新
- Showcase のタイル分類を「年代 × スタイル」から「ムード × スタイル」に変更
- README 全面書き換え（機能セクション追加・古着言及を全削除・旧ナレッジ系リリースノート整理）

内部資産（スタイルカタログ・テストフィクスチャ・`/knowledge-update` スキル / Curator エージェント / `.claude/knowledge-base/`・CLAUDE.md／rules の古着記述）は別 PR で扱う。

## Test plan

- [x] `npm run lint` — PASS
- [x] `npm run typecheck` — PASS
- [x] `npm run build` — PASS（`/icon.svg` と `/apple-icon` がルート登録）
- [x] `npm test -- --run` — PASS 559/559
- [ ] Vercel Preview で favicon と OG/Twitter card の表示確認
- [ ] LP のコピーが古着文脈を含まないことを目視確認

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Apple アプリアイコン（180x180）を動的に生成するサポートを追加

* **Documentation**
  * README を更新し、アプリ紹介、技術スタック、開発コマンド、リリースノート履歴を刷新

* **Updates**
  * ランディングページ全体のテキスト・メッセージングを更新
  * アプリメタデータ（タイトル、説明、OGP、Twitter カード）を刷新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fune6900/DIG/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->