### PR TITLE
Showcase: fetch random Unsplash photos per request

### DIFF
--- a/app/(public)/_components/landing/ShowcaseSection.tsx
+++ b/app/(public)/_components/landing/ShowcaseSection.tsx
@@ -1,37 +1,62 @@
+import Image from "next/image";
 import { FadeIn, StaggerChildren, StaggerItem } from "@/components/ui/motion";
+import {
+  fetchRandomUnsplashPhoto,
+  type UnsplashPhoto,
+} from "@/services/unsplash-service";
 
-// Showcase はトップ LP のギャラリー帯。実画像差し替えは後続 PR で対応する想定で、
-// 今は CSS グラデーションのプレースホルダタイルで構成する。
+// Showcase はトップ LP のギャラリー帯。各タイルのテーマで Unsplash の
+// /photos/random を叩き、毎リクエスト別画像を表示する。API キー未設定や
+// 失敗時は CSS グラデーションのプレースホルダにフォールバックする。
 const SHOWCASE_TILES = [
   {
     mood: "MINIMAL",
     style: "Monotone",
+    query: "minimalist fashion monochrome",
     grad: "from-denim-dark via-denim to-denim-light",
   },
   {
     mood: "STATEMENT",
     style: "Color",
+    query: "colorful bold outfit",
     grad: "from-canvas via-denim-dark to-rust",
   },
-  { mood: "DAILY", style: "Casual", grad: "from-denim to-canvas" },
+  {
+    mood: "DAILY",
+    style: "Casual",
+    query: "casual everyday fashion",
+    grad: "from-denim to-canvas",
+  },
   {
     mood: "LAYER",
     style: "Layering",
+    query: "layered outfit fashion",
     grad: "from-denim-light via-offwhite-subtle to-denim",
   },
   {
     mood: "EARTH",
     style: "Outdoor",
+    query: "outdoor earth tone fashion",
     grad: "from-rust via-rust-light to-offwhite-subtle",
   },
   {
     mood: "STREET",
     style: "Edge",
+    query: "street style edgy fashion",
     grad: "from-canvas-subtle via-denim to-denim-light",
   },
 ] as const;
 
-export function ShowcaseSection() {
+function buildAlt(photo: UnsplashPhoto, fallback: string): string {
+  const subject = photo.alt_description?.trim() || fallback;
+  return `${subject} — Photo by ${photo.user.name} on Unsplash`;
+}
+
+export async function ShowcaseSection() {
+  const photos = await Promise.all(
+    SHOWCASE_TILES.map((tile) => fetchRandomUnsplashPhoto(tile.query)),
+  );
+
   return (
     <section className="relative overflow-hidden bg-offwhite-subtle px-6 py-24 dark:bg-canvas-subtle sm:py-32">
       <div className="mx-auto max-w-6xl">
@@ -49,7 +74,7 @@ export function ShowcaseSection() {
             アーカイブの断片。
           </h2>
           <p className="mt-6 max-w-xl text-sm leading-relaxed text-denim/70 dark:text-offwhite/60 sm:text-base">
-            記録されたコーデから、スタイルとムードの片鱗を覗き見る。
+            スタイルとムードの片鱗を、毎日違う一枚で。
           </p>
         </FadeIn>
 
@@ -59,27 +84,41 @@ export function ShowcaseSection() {
           className="grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4"
           stagger={0.08}
         >
-          {SHOWCASE_TILES.map((tile, idx) => (
-            <StaggerItem
-              key={`${tile.mood}-${tile.style}-${idx}`}
-              as="li"
-              className="group relative aspect-[3/4] overflow-hidden border border-denim/10 dark:border-offwhite/10"
-            >
-              <div
-                aria-hidden="true"
-                className={`absolute inset-0 bg-gradient-to-br ${tile.grad}`}
-              />
-              <div className="absolute inset-0 bg-canvas/20 transition-colors group-hover:bg-canvas/40" />
-              <div className="absolute inset-x-0 bottom-0 flex flex-col gap-1 p-4">
-                <span className="text-2xs font-medium tracking-[0.3em] text-offwhite/70 uppercase">
-                  {tile.mood}
-                </span>
-                <span className="font-display text-xl tracking-widest text-offwhite sm:text-2xl">
-                  {tile.style}
-                </span>
-              </div>
-            </StaggerItem>
-          ))}
+          {SHOWCASE_TILES.map((tile, idx) => {
+            const photo = photos[idx];
+            return (
+              <StaggerItem
+                key={`${tile.mood}-${tile.style}-${idx}`}
+                as="li"
+                className="group relative aspect-[3/4] overflow-hidden border border-denim/10 dark:border-offwhite/10"
+              >
+                {photo ? (
+                  <Image
+                    src={photo.urls.regular}
+                    alt={buildAlt(photo, `${tile.style} fashion`)}
+                    fill
+                    sizes="(max-width: 640px) 50vw, 33vw"
+                    className="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.04]"
+                    unoptimized
+                  />
+                ) : (
+                  <div
+                    aria-hidden="true"
+                    className={`absolute inset-0 bg-gradient-to-br ${tile.grad}`}
+                  />
+                )}
+                <div className="absolute inset-0 bg-canvas/30 transition-colors group-hover:bg-canvas/50" />
+                <div className="absolute inset-x-0 bottom-0 flex flex-col gap-1 p-4">
+                  <span className="text-2xs font-medium tracking-[0.3em] text-offwhite/70 uppercase">
+                    {tile.mood}
+                  </span>
+                  <span className="font-display text-xl tracking-widest text-offwhite sm:text-2xl">
+                    {tile.style}
+                  </span>
+                </div>
+              </StaggerItem>
+            );
+          })}
         </StaggerChildren>
       </div>
     </section>

--- a/services/unsplash-service.ts
+++ b/services/unsplash-service.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export interface UnsplashPhoto {
   id: string;
   urls: { regular: string; small: string };
@@ -7,6 +9,21 @@ export interface UnsplashPhoto {
   links: { html: string };
   tags?: { title: string }[];
 }
+
+const UnsplashPhotoSchema = z.object({
+  id: z.string().min(1),
+  urls: z.object({
+    regular: z.url(),
+    small: z.url(),
+  }),
+  description: z.string().nullable().optional(),
+  alt_description: z.string().nullable().optional(),
+  user: z.object({
+    name: z.string(),
+    links: z.object({ html: z.url() }),
+  }),
+  links: z.object({ html: z.url() }),
+});
 
 interface UnsplashApiResponse {
   total: number;
@@ -52,4 +69,47 @@ export async function searchUnsplashPhotos(params: {
     photos: data.results,
     totalPages: data.total_pages,
   };
+}
+
+/**
+ * Unsplash /photos/random から 1 枚のランダム写真を取得する。
+ *
+ * - LP の Showcase で使用するため、API キー未設定・HTTP 失敗・ネットワーク
+ *   エラー・スキーマ不整合のすべてで `null` を返し、呼び出し側がグラデーション
+ *   等のフォールバックに切り替えられるようにする（throws しない）。
+ * - `cache: "no-store"` で毎リクエスト新しい画像を取得する。
+ */
+export async function fetchRandomUnsplashPhoto(
+  query: string,
+): Promise<UnsplashPhoto | null> {
+  const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+  if (!accessKey) return null;
+
+  const searchParams = new URLSearchParams({
+    query,
+    orientation: "portrait",
+  });
+  const url = `https://api.unsplash.com/photos/random?${searchParams.toString()}`;
+
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(8000),
+      cache: "no-store",
+      headers: {
+        Authorization: `Client-ID ${accessKey}`,
+      },
+    });
+
+    if (!response.ok) return null;
+
+    const data = (await response.json().catch(() => null)) as unknown;
+    if (data === null) return null;
+
+    const parsed = UnsplashPhotoSchema.safeParse(data);
+    if (!parsed.success) return null;
+
+    return parsed.data as UnsplashPhoto;
+  } catch {
+    return null;
+  }
 }

--- a/tests/unit/services/unsplash-service.test.ts
+++ b/tests/unit/services/unsplash-service.test.ts
@@ -5,7 +5,10 @@
 // URL 組み立て・Authorization ヘッダ・クエリ補強・エラーハンドリングを検証する。
 // ---------------------------------------------------------------------------
 
-import { searchUnsplashPhotos } from "@/services/unsplash-service";
+import {
+  fetchRandomUnsplashPhoto,
+  searchUnsplashPhotos,
+} from "@/services/unsplash-service";
 
 const MOCK_ACCESS_KEY = "test-access-key-12345";
 
@@ -58,13 +61,11 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 describe("searchUnsplashPhotos — URL 組み立て", () => {
   it("Unsplash search/photos エンドポイントを叩く", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(makeUnsplashApiResponse()), {
-          status: 200,
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeUnsplashApiResponse()), {
+        status: 200,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await searchUnsplashPhotos({ query: "denim jacket", page: 1, perPage: 30 });
@@ -74,13 +75,11 @@ describe("searchUnsplashPhotos — URL 組み立て", () => {
   });
 
   it("query パラメータが URL に含まれる", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(makeUnsplashApiResponse()), {
-          status: 200,
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeUnsplashApiResponse()), {
+        status: 200,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await searchUnsplashPhotos({ query: "M-65", page: 1, perPage: 30 });
@@ -90,13 +89,11 @@ describe("searchUnsplashPhotos — URL 組み立て", () => {
   });
 
   it("query に 'outfit fashion' サフィックスが付与される", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(makeUnsplashApiResponse()), {
-          status: 200,
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeUnsplashApiResponse()), {
+        status: 200,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await searchUnsplashPhotos({ query: "denim", page: 1, perPage: 30 });
@@ -109,13 +106,11 @@ describe("searchUnsplashPhotos — URL 組み立て", () => {
   });
 
   it("page パラメータが URL に含まれる", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(makeUnsplashApiResponse()), {
-          status: 200,
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeUnsplashApiResponse()), {
+        status: 200,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await searchUnsplashPhotos({ query: "jacket", page: 3, perPage: 30 });
@@ -125,13 +120,11 @@ describe("searchUnsplashPhotos — URL 組み立て", () => {
   });
 
   it("per_page パラメータが URL に含まれる", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(makeUnsplashApiResponse()), {
-          status: 200,
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeUnsplashApiResponse()), {
+        status: 200,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 20 });
@@ -146,13 +139,11 @@ describe("searchUnsplashPhotos — URL 組み立て", () => {
 // ---------------------------------------------------------------------------
 describe("searchUnsplashPhotos — Authorization ヘッダ", () => {
   it("Authorization ヘッダに 'Client-ID <UNSPLASH_ACCESS_KEY>' を設定する", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(makeUnsplashApiResponse()), {
-          status: 200,
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeUnsplashApiResponse()), {
+        status: 200,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 30 });
@@ -187,13 +178,11 @@ describe("searchUnsplashPhotos — 成功時", () => {
   });
 
   it("photos の各要素に id / urls / user が含まれる", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(makeUnsplashApiResponse()), {
-          status: 200,
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeUnsplashApiResponse()), {
+        status: 200,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await searchUnsplashPhotos({
@@ -250,13 +239,11 @@ describe("searchUnsplashPhotos — HTTP エラー", () => {
   });
 
   it("HTTP 403 のとき Error をスローする", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify({ errors: ["Forbidden"] }), {
-          status: 403,
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ errors: ["Forbidden"] }), {
+        status: 403,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
@@ -301,5 +288,185 @@ describe("searchUnsplashPhotos — ネットワークエラー", () => {
     await expect(
       searchUnsplashPhotos({ query: "jacket", page: 1, perPage: 30 }),
     ).rejects.toThrow("Failed to fetch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRandomUnsplashPhoto
+// ランダム取得は LP の Showcase で使用。LP を壊さないため失敗時は null を返す
+// ---------------------------------------------------------------------------
+const makeRandomPhoto = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: overrides.id ?? "rand-1",
+  urls: {
+    regular: "https://images.unsplash.com/photo-rand/regular",
+    small: "https://images.unsplash.com/photo-rand/small",
+    ...(typeof overrides.urls === "object" && overrides.urls !== null
+      ? overrides.urls
+      : {}),
+  },
+  description: overrides.description ?? null,
+  alt_description: overrides.alt_description ?? "minimal fashion",
+  user: overrides.user ?? {
+    name: "Anna Sample",
+    links: { html: "https://unsplash.com/@anna" },
+  },
+  links: overrides.links ?? {
+    html: "https://unsplash.com/photos/rand-1",
+  },
+});
+
+describe("fetchRandomUnsplashPhoto — URL / ヘッダ / キャッシュ", () => {
+  it("photos/random エンドポイントを叩く", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeRandomPhoto()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchRandomUnsplashPhoto("minimalist fashion");
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain("https://api.unsplash.com/photos/random");
+  });
+
+  it("query パラメータが URL に含まれる", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeRandomPhoto()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchRandomUnsplashPhoto("street fashion");
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    // URLSearchParams は空白を '+' に変換するので、'+' のままで検査する
+    expect(calledUrl).toContain("query=street+fashion");
+  });
+
+  it("orientation=portrait をデフォルトで送る", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeRandomPhoto()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchRandomUnsplashPhoto("monochrome");
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain("orientation=portrait");
+  });
+
+  it("Authorization ヘッダに 'Client-ID <KEY>' を設定する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeRandomPhoto()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchRandomUnsplashPhoto("layering");
+
+    const calledOptions: RequestInit = fetchMock.mock.calls[0][1];
+    const headers = calledOptions.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(`Client-ID ${MOCK_ACCESS_KEY}`);
+  });
+
+  it("cache: 'no-store' を指定して毎回新規取得する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makeRandomPhoto()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchRandomUnsplashPhoto("color block");
+
+    const calledOptions: RequestInit = fetchMock.mock.calls[0][1];
+    expect(calledOptions.cache).toBe("no-store");
+  });
+});
+
+describe("fetchRandomUnsplashPhoto — 成功時", () => {
+  it("UnsplashPhoto を返す", async () => {
+    const photo = makeRandomPhoto({ id: "ok-1" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(photo), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRandomUnsplashPhoto("outdoor");
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("ok-1");
+    expect(result?.urls.regular).toMatch(/^https:\/\/images\.unsplash\.com\//);
+    expect(result?.user.name).toBe("Anna Sample");
+  });
+});
+
+describe("fetchRandomUnsplashPhoto — フォールバック", () => {
+  it("UNSPLASH_ACCESS_KEY 未設定なら fetch を叩かず null を返す", async () => {
+    vi.unstubAllEnvs();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRandomUnsplashPhoto("anything");
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("HTTP 401/403/429/500 はすべて null を返す", async () => {
+    for (const status of [401, 403, 429, 500]) {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response("err", { status }));
+      vi.stubGlobal("fetch", fetchMock);
+      const result = await fetchRandomUnsplashPhoto("q");
+      expect(result).toBeNull();
+    }
+  });
+
+  it("fetch が reject したとき null を返す（throws しない）", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRandomUnsplashPhoto("q");
+
+    expect(result).toBeNull();
+  });
+
+  it("レスポンスが期待形式と異なる（urls.regular 欠落）とき null を返す", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "broken",
+          urls: {},
+          user: { name: "x", links: { html: "https://u" } },
+          links: { html: "https://u" },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRandomUnsplashPhoto("q");
+
+    expect(result).toBeNull();
+  });
+
+  it("レスポンスが JSON として壊れているとき null を返す", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("not json", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRandomUnsplashPhoto("q");
+
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- LP の「アーカイブの断片」セクション（`ShowcaseSection`）の各タイル画像を Unsplash `/photos/random` で動的取得
- 毎リクエスト別画像を表示。DB / CDN キャッシュは介さない（`cache: "no-store"`）
- API キー未設定・HTTP 失敗・JSON 不正・スキーマ不整合のいずれも `null` を返し、CSS グラデーションにフォールバック（LP は API キー無しでも動作）
- `fetchRandomUnsplashPhoto` を新規追加。Zod でレスポンス検証
- alt 属性に「<subject> — Photo by <name> on Unsplash」のクレジットを含め attribution に対応
- `next/image` の `unoptimized` で表示（毎回違う画像で Next.js Image 最適化キャッシュが無意味）

## Test plan

- [x] `npm run lint` — PASS
- [x] `npm run typecheck` — PASS
- [x] `npm run build` — PASS（`/` が dynamic ルートに変更）
- [x] `npm test -- --run` — PASS 570/570（+11 ケース追加）
- [ ] Vercel Preview で `UNSPLASH_ACCESS_KEY` を環境変数に設定し画像が表示されることを確認
- [ ] 環境変数未設定でグラデーションフォールバックされることを確認
- [ ] ページリロードで別の画像が出ることを確認

## 補足

- 既存の `searchUnsplashPhotos`（throws 設計、search/photos エンドポイント）には影響なし
- ルートが SSG → SSR に変更されるため LP の初回レスポンスがやや遅くなる（6 並列 Unsplash fetch ぶん）。デモ用と割り切る

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)