### PR TITLE
Search: add Pexels (UI labeled as Pinterest) as second source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,8 @@ NOTION_KNOWLEDGE_PARENT_PAGE_URL=
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Unsplash API（着こなし検索機能。サーバ側のみ使用）
+# Unsplash API（着こなし検索機能・LP Showcase。サーバ側のみ使用）
 UNSPLASH_ACCESS_KEY=
+
+# Pexels API（着こなし検索機能の第二ソース。UI 上は "Pinterest" として表示。サーバ側のみ使用）
+PEXELS_API_KEY=

--- a/app/actions/search.ts
+++ b/app/actions/search.ts
@@ -2,8 +2,56 @@
 
 import { SnapSearchInputSchema } from "@/types/snap";
 import type { SnapSummary } from "@/types/snap";
-import { findSnapsByQuery, upsertSnaps } from "@/services/snap-service";
+import {
+  findSnapsByQuery,
+  upsertPexelsSnaps,
+  upsertSnaps,
+} from "@/services/snap-service";
 import { searchUnsplashPhotos } from "@/services/unsplash-service";
+import { searchPexelsPhotos } from "@/services/pexels-service";
+
+/**
+ * Unsplash と Pexels を Promise.allSettled で並列取得し、得られたものを DB
+ * にキャッシュする。両方失敗時は `fetchedFromApi=false`、片方成功時は
+ * 成功側の totalPages を採用する。
+ */
+async function fetchAndCacheFromSources(
+  query: string,
+  page: number,
+  pageSize: number,
+): Promise<{ fetchedFromApi: boolean; totalPages: number }> {
+  const [unsplashResult, pexelsResult] = await Promise.allSettled([
+    searchUnsplashPhotos({ query, page, perPage: pageSize }),
+    searchPexelsPhotos({ query, page, perPage: pageSize }),
+  ]);
+
+  let fetchedFromApi = false;
+  let totalPages = 0;
+
+  if (unsplashResult.status === "fulfilled") {
+    const { photos, totalPages: tp } = unsplashResult.value;
+    try {
+      await upsertSnaps(photos, query);
+      fetchedFromApi = true;
+      totalPages = Math.max(totalPages, tp);
+    } catch {
+      // DB 書き込み失敗は黙殺（後段 findSnapsByQuery で初回 items を返す）
+    }
+  }
+
+  if (pexelsResult.status === "fulfilled") {
+    const { photos, totalPages: tp } = pexelsResult.value;
+    try {
+      await upsertPexelsSnaps(photos, query);
+      fetchedFromApi = true;
+      totalPages = Math.max(totalPages, tp);
+    } catch {
+      // 同上
+    }
+  }
+
+  return { fetchedFromApi, totalPages };
+}
 
 type ActionResult<T> =
   | { data: T; error: null }
@@ -58,17 +106,14 @@ export async function searchSnapsAction(input: unknown): Promise<
 
       if (shouldFetchFromApi) {
         let items = initialItems;
-        let totalPages = 0;
-        let fetchedFromApi = false;
 
-        try {
-          const { photos, totalPages: tp } = await searchUnsplashPhotos({
-            query: query as string,
-            page,
-            perPage: pageSize,
-          });
-          totalPages = tp;
-          await upsertSnaps(photos, query as string);
+        const { fetchedFromApi, totalPages } = await fetchAndCacheFromSources(
+          query as string,
+          page,
+          pageSize,
+        );
+
+        if (fetchedFromApi) {
           items = await findSnapsByQuery({
             query,
             styles,
@@ -76,9 +121,6 @@ export async function searchSnapsAction(input: unknown): Promise<
             page,
             pageSize,
           });
-          fetchedFromApi = true;
-        } catch {
-          // Unsplash 失敗時は初回取得の items をそのまま使う
         }
 
         const hasMore = fetchedFromApi
@@ -125,21 +167,15 @@ export async function searchSnapsAction(input: unknown): Promise<
 
   if (shouldFetchFromApi) {
     let items = initialItems;
-    let totalPages = 0;
-    let fetchedFromApi = false;
 
-    try {
-      const { photos, totalPages: tp } = await searchUnsplashPhotos({
-        query: query as string,
-        page,
-        perPage: pageSize,
-      });
-      totalPages = tp;
-      await upsertSnaps(photos, query as string);
+    const { fetchedFromApi, totalPages } = await fetchAndCacheFromSources(
+      query as string,
+      page,
+      pageSize,
+    );
+
+    if (fetchedFromApi) {
       items = await findSnapsByQuery({ query, page, pageSize });
-      fetchedFromApi = true;
-    } catch {
-      // Unsplash 失敗時は初回取得の items をそのまま使う
     }
 
     const hasMore = fetchedFromApi

--- a/components/features/search/SnapCard.tsx
+++ b/components/features/search/SnapCard.tsx
@@ -1,16 +1,25 @@
 import Image from "next/image";
 import Link from "next/link";
 import { HoverLift } from "@/components/ui/motion";
-import type { SnapSummary } from "@/types/snap";
+import type { SnapSource, SnapSummary } from "@/types/snap";
 
 interface SnapCardProps {
   snap: SnapSummary;
 }
 
+// 内部 source 値を UI 表示用ラベルへマップ。
+// "pexels" は意図的に "Pinterest" と表示する（ブランディング都合・要件）。
+const SOURCE_LABEL: Record<SnapSource, string> = {
+  unsplash: "Unsplash",
+  pexels: "Pinterest",
+};
+
 export function SnapCard({ snap }: SnapCardProps) {
   const alt = snap.authorName
     ? `${snap.authorName} のスナップ`
     : "スナップ画像";
+
+  const sourceLabel = SOURCE_LABEL[snap.source];
 
   return (
     <HoverLift lift={3} scale={1.015}>
@@ -27,6 +36,12 @@ export function SnapCard({ snap }: SnapCardProps) {
             sizes="(max-width: 768px) 50vw, (max-width: 1280px) 33vw, 25vw"
             className="object-cover transition-transform duration-500 ease-out hover:scale-[1.04]"
           />
+          <span
+            data-testid="snap-source-badge"
+            className="pointer-events-none absolute left-2 top-2 inline-flex items-center bg-denim-dark/80 px-2 py-0.5 text-2xs font-medium tracking-[0.2em] text-offwhite uppercase"
+          >
+            {sourceLabel}
+          </span>
         </div>
       </Link>
     </HoverLift>

--- a/lib/image-hosts.ts
+++ b/lib/image-hosts.ts
@@ -6,7 +6,10 @@
 // ハードコードしており、next.config.ts が動的に Supabase ホストを追加するのと
 // 同期していなかった。本ファイルで両者を統合する。
 
-export const BASE_ALLOWED_IMAGE_HOSTS = ["images.unsplash.com"] as const;
+export const BASE_ALLOWED_IMAGE_HOSTS = [
+  "images.unsplash.com",
+  "images.pexels.com",
+] as const;
 
 export function resolveSupabaseHost(): string | null {
   const url = process.env.SUPABASE_URL;

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ const remotePatterns: NonNullable<NextConfig["images"]>["remotePatterns"] = [
     protocol: "https",
     hostname: "images.unsplash.com",
   },
+  {
+    protocol: "https",
+    hostname: "images.pexels.com",
+  },
 ];
 
 if (supabaseHost) {

--- a/services/pexels-service.ts
+++ b/services/pexels-service.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+// Pexels Search API のレスポンス型。UI 上は "Pinterest" バッジとして表示する
+// が、内部実装・DB・型はすべて "pexels" で統一する。
+export interface PexelsPhoto {
+  id: number;
+  width: number;
+  height: number;
+  url: string;
+  photographer: string;
+  photographer_url: string;
+  src: {
+    original: string;
+    large: string;
+    medium: string;
+  };
+  alt: string;
+}
+
+const PexelsPhotoSchema = z.object({
+  id: z.number(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  url: z.url(),
+  photographer: z.string(),
+  photographer_url: z.url(),
+  src: z.object({
+    original: z.url(),
+    large: z.url(),
+    medium: z.url().optional(),
+  }),
+  alt: z.string().optional(),
+});
+
+const PexelsApiResponseSchema = z.object({
+  total_results: z.number().optional(),
+  per_page: z.number().optional(),
+  page: z.number().optional(),
+  photos: z.array(z.unknown()),
+});
+
+/**
+ * Pexels /v1/search を叩いてファッション系画像を取得する。
+ *
+ * 並列検索（Unsplash と Promise.allSettled で同時実行）で片方の失敗が
+ * 全体を倒さないよう、すべての失敗パスで `{ photos: [], totalPages: 0 }`
+ * を返す（throws しない）。
+ */
+export async function searchPexelsPhotos(params: {
+  query: string;
+  page: number;
+  perPage: number;
+}): Promise<{ photos: PexelsPhoto[]; totalPages: number }> {
+  const accessKey = process.env.PEXELS_API_KEY;
+  if (!accessKey) return { photos: [], totalPages: 0 };
+
+  // Pexels は keyword ベース。fashion 系のサフィックスを付けて検索精度を底上げ。
+  const enhancedQuery = `${params.query} outfit fashion`;
+  const searchParams = new URLSearchParams({
+    query: enhancedQuery,
+    page: String(params.page),
+    per_page: String(params.perPage),
+  });
+
+  const url = `https://api.pexels.com/v1/search?${searchParams.toString()}`;
+
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(8000),
+      // Pexels の Authorization は Bearer プレフィックスなしで API キーを直接渡す
+      headers: { Authorization: accessKey },
+    });
+
+    if (!response.ok) return { photos: [], totalPages: 0 };
+
+    const data = (await response.json().catch(() => null)) as unknown;
+    if (data === null) return { photos: [], totalPages: 0 };
+
+    const parsedEnvelope = PexelsApiResponseSchema.safeParse(data);
+    if (!parsedEnvelope.success) return { photos: [], totalPages: 0 };
+
+    // 配列内の不正要素は個別に弾いて有効分のみ返す
+    const validPhotos: PexelsPhoto[] = [];
+    for (const raw of parsedEnvelope.data.photos) {
+      const parsed = PexelsPhotoSchema.safeParse(raw);
+      if (parsed.success) validPhotos.push(parsed.data as PexelsPhoto);
+    }
+
+    const totalResults = parsedEnvelope.data.total_results ?? 0;
+    const perPage = parsedEnvelope.data.per_page ?? params.perPage;
+    const totalPages = perPage > 0 ? Math.ceil(totalResults / perPage) : 0;
+
+    return { photos: validPhotos, totalPages };
+  } catch {
+    return { photos: [], totalPages: 0 };
+  }
+}

--- a/services/snap-service.ts
+++ b/services/snap-service.ts
@@ -1,7 +1,36 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
-import type { Snap, SnapSummary } from "@/types/snap";
+import {
+  SNAP_SOURCES,
+  type Snap,
+  type SnapSource,
+  type SnapSummary,
+} from "@/types/snap";
 import type { UnsplashPhoto } from "@/services/unsplash-service";
+import type { PexelsPhoto } from "@/services/pexels-service";
+
+// Prisma 側で source カラムは string 型のため、DB から読んだ値を SnapSourceEnum
+// に絞り込む型ガード。未知の source 値は呼び出し側で安全に "unsplash" などへ
+// 正規化する（既存レコードはすべて "unsplash" のため実害なし）。
+function isSnapSource(value: string): value is SnapSource {
+  return (SNAP_SOURCES as readonly string[]).includes(value);
+}
+
+function normalizeSummary(record: {
+  id: string;
+  imageUrl: string;
+  authorName: string | null;
+  sourceUrl: string;
+  source: string;
+}): SnapSummary {
+  return {
+    id: record.id,
+    imageUrl: record.imageUrl,
+    authorName: record.authorName,
+    sourceUrl: record.sourceUrl,
+    source: isSnapSource(record.source) ? record.source : "unsplash",
+  };
+}
 
 export async function findSnapsByQuery(params: {
   query?: string;
@@ -52,9 +81,10 @@ export async function findSnapsByQuery(params: {
       imageUrl: true,
       authorName: true,
       sourceUrl: true,
+      source: true,
     },
   });
-  return records;
+  return records.map(normalizeSummary);
 }
 
 export async function getSnapById(id: string): Promise<Snap | null> {
@@ -91,36 +121,63 @@ export async function findSimilarSnaps(params: {
       imageUrl: true,
       authorName: true,
       sourceUrl: true,
+      source: true,
     },
   });
 
-  return records;
+  return records.map(normalizeSummary);
 }
 
-/**
- * Unsplash から取得した写真群を Snap テーブルにキャッシュする。
- *
- * - 新規写真: `createMany({ skipDuplicates: true })` で 1 クエリにバルク INSERT
- *   （N 件並列 upsert を発行していた旧実装の DB コネクション枯渇リスクを解消）
- * - 既存写真: `searchQueries` に `query` が未登録のものだけ `update` で push
- *   （同一画像が別キーワードでヒットした履歴を保持し、過去キーワードからの
- *   再検索でも引き続き返るようにする）
- *
- * 競合: 別リクエストが同時に同 externalId を upsert する可能性は低いが、
- * `createMany.skipDuplicates` で重複は黙殺、`update.searchQueries.push` は
- * Prisma 内部で配列追記される。完全な原子性が必要になったら $transaction
- * （Interactive）に切り替える。
- */
-export async function upsertSnaps(
-  photos: UnsplashPhoto[],
+// ---------------------------------------------------------------------------
+// upsertSnaps: 取得元サービス（Unsplash / Pexels）から得た写真を Snap テーブル
+// にキャッシュする。source ごとに正規化済みフィールド (ExternalPhoto) に変換
+// してから 1 つの実装でハンドリングする。
+// ---------------------------------------------------------------------------
+interface ExternalPhoto {
+  externalId: string;
+  imageUrl: string;
+  sourceUrl: string;
+  authorName: string;
+  authorUrl: string;
+  description: string | null;
+  tags: string[];
+}
+
+function normalizeUnsplash(photo: UnsplashPhoto): ExternalPhoto {
+  return {
+    externalId: photo.id,
+    imageUrl: photo.urls.regular,
+    sourceUrl: photo.links.html,
+    authorName: photo.user.name,
+    authorUrl: photo.user.links.html,
+    description: photo.alt_description ?? photo.description,
+    tags: photo.tags?.map((t) => t.title) ?? [],
+  };
+}
+
+function normalizePexels(photo: PexelsPhoto): ExternalPhoto {
+  return {
+    externalId: String(photo.id),
+    imageUrl: photo.src.large,
+    sourceUrl: photo.url,
+    authorName: photo.photographer,
+    authorUrl: photo.photographer_url,
+    description: photo.alt || null,
+    tags: [],
+  };
+}
+
+async function upsertExternalPhotos(
+  source: SnapSource,
+  photos: ExternalPhoto[],
   query: string,
 ): Promise<void> {
   if (photos.length === 0) return;
 
-  const externalIds = photos.map((p) => p.id);
+  const externalIds = photos.map((p) => p.externalId);
   const existing = await prisma.snap.findMany({
     where: {
-      source: "unsplash",
+      source,
       externalId: { in: externalIds },
     },
     select: { externalId: true, searchQueries: true },
@@ -129,24 +186,24 @@ export async function upsertSnaps(
     existing.map((e) => [e.externalId, e.searchQueries]),
   );
 
-  const toCreate = photos.filter((p) => !existingMap.has(p.id));
+  const toCreate = photos.filter((p) => !existingMap.has(p.externalId));
   const toAppend = photos.filter((p) => {
-    const queries = existingMap.get(p.id);
+    const queries = existingMap.get(p.externalId);
     return queries !== undefined && !queries.includes(query);
   });
 
   if (toCreate.length > 0) {
     await prisma.snap.createMany({
       data: toCreate.map((photo) => ({
-        source: "unsplash",
-        externalId: photo.id,
-        imageUrl: photo.urls.regular,
-        sourceUrl: photo.links.html,
-        authorName: photo.user.name,
-        authorUrl: photo.user.links.html,
+        source,
+        externalId: photo.externalId,
+        imageUrl: photo.imageUrl,
+        sourceUrl: photo.sourceUrl,
+        authorName: photo.authorName,
+        authorUrl: photo.authorUrl,
         title: null,
-        description: photo.alt_description ?? photo.description,
-        tags: photo.tags?.map((t) => t.title) ?? [],
+        description: photo.description,
+        tags: photo.tags,
         searchQueries: [query],
         colorCategories: [],
       })),
@@ -159,11 +216,40 @@ export async function upsertSnaps(
       toAppend.map((photo) =>
         prisma.snap.update({
           where: {
-            source_externalId: { source: "unsplash", externalId: photo.id },
+            source_externalId: { source, externalId: photo.externalId },
           },
           data: { searchQueries: { push: query } },
         }),
       ),
     );
   }
+}
+
+/**
+ * Unsplash から取得した写真群を Snap テーブルにキャッシュする。
+ *
+ * - 新規写真: `createMany({ skipDuplicates: true })` で 1 クエリにバルク INSERT
+ * - 既存写真: `searchQueries` に `query` が未登録のものだけ `update` で push
+ *   （同一画像が別キーワードでヒットした履歴を保持）
+ *
+ * 競合: `createMany.skipDuplicates` で重複は黙殺、`update.searchQueries.push`
+ * は Prisma 内部で配列追記される。完全な原子性が必要になったら $transaction
+ * （Interactive）に切り替える。
+ */
+export async function upsertSnaps(
+  photos: UnsplashPhoto[],
+  query: string,
+): Promise<void> {
+  await upsertExternalPhotos("unsplash", photos.map(normalizeUnsplash), query);
+}
+
+/**
+ * Pexels から取得した写真群を Snap テーブルにキャッシュする。
+ * upsertSnaps と同じ upsert ロジックを source: "pexels" で再利用する。
+ */
+export async function upsertPexelsSnaps(
+  photos: PexelsPhoto[],
+  query: string,
+): Promise<void> {
+  await upsertExternalPhotos("pexels", photos.map(normalizePexels), query);
 }

--- a/tests/unit/components/SnapCard.test.tsx
+++ b/tests/unit/components/SnapCard.test.tsx
@@ -17,6 +17,7 @@ const mockSnap: SnapSummary = {
   imageUrl: "https://images.unsplash.com/photo-abc/regular",
   authorName: "Jane Doe",
   sourceUrl: "https://unsplash.com/photos/photo-abc",
+  source: "unsplash",
 };
 
 const mockSnapNoAuthor: SnapSummary = {
@@ -24,6 +25,15 @@ const mockSnapNoAuthor: SnapSummary = {
   imageUrl: "https://images.unsplash.com/photo-xyz/regular",
   authorName: null,
   sourceUrl: "https://unsplash.com/photos/photo-xyz",
+  source: "unsplash",
+};
+
+const mockSnapPexels: SnapSummary = {
+  id: "snap-uuid-3",
+  imageUrl: "https://images.pexels.com/photos/123/large.jpg",
+  authorName: "Sample Photographer",
+  sourceUrl: "https://www.pexels.com/photo/sample-123/",
+  source: "pexels",
 };
 
 // ---------------------------------------------------------------------------
@@ -89,5 +99,21 @@ describe("SnapCard", () => {
     expect(
       screen.queryByText("https://unsplash.com/photos/photo-abc"),
     ).not.toBeInTheDocument();
+  });
+
+  describe("ソースバッジ", () => {
+    it("source='unsplash' のとき 'Unsplash' バッジが表示される", () => {
+      render(<SnapCard snap={mockSnap} />);
+      const badge = screen.getByTestId("snap-source-badge");
+      expect(badge).toHaveTextContent("Unsplash");
+    });
+
+    it("source='pexels' のとき UI 表記は 'Pinterest' になる", () => {
+      render(<SnapCard snap={mockSnapPexels} />);
+      const badge = screen.getByTestId("snap-source-badge");
+      expect(badge).toHaveTextContent("Pinterest");
+      // 内部実装名 "Pexels" が漏れていないこと
+      expect(badge).not.toHaveTextContent("Pexels");
+    });
   });
 });

--- a/tests/unit/components/SnapGrid.test.tsx
+++ b/tests/unit/components/SnapGrid.test.tsx
@@ -75,6 +75,7 @@ const makeSnap = (id: string): SnapSummary => ({
   imageUrl: `https://images.unsplash.com/${id}/regular`,
   authorName: "Test Author",
   sourceUrl: `https://unsplash.com/photos/${id}`,
+  source: "unsplash",
 });
 
 const SNAPS_3 = [makeSnap("a"), makeSnap("b"), makeSnap("c")];

--- a/tests/unit/services/pexels-service.test.ts
+++ b/tests/unit/services/pexels-service.test.ts
@@ -1,0 +1,266 @@
+// ---------------------------------------------------------------------------
+// pexels-service のユニットテスト
+//
+// fetch を vi.stubGlobal でモックして外部通信を完全遮断する。
+// Pexels API は Unsplash と並列で呼ぶため、片方失敗を許容できるよう
+// すべての失敗パスで { photos: [], totalPages: 0 } を返す設計を検証する。
+// ---------------------------------------------------------------------------
+
+import { searchPexelsPhotos } from "@/services/pexels-service";
+
+const MOCK_ACCESS_KEY = "pexels-test-key-xyz";
+
+const makePexelsApiResponse = (
+  overrides: Partial<{
+    total_results: number;
+    per_page: number;
+    page: number;
+    photos: unknown[];
+  }> = {},
+) => ({
+  total_results: overrides.total_results ?? 100,
+  per_page: overrides.per_page ?? 30,
+  page: overrides.page ?? 1,
+  next_page: "https://api.pexels.com/v1/search?page=2",
+  photos: overrides.photos ?? [
+    {
+      id: 12345,
+      width: 1200,
+      height: 1600,
+      url: "https://www.pexels.com/photo/sample-12345/",
+      photographer: "Sample Photographer",
+      photographer_url: "https://www.pexels.com/@sample",
+      photographer_id: 99,
+      src: {
+        original: "https://images.pexels.com/photos/12345/orig.jpg",
+        large: "https://images.pexels.com/photos/12345/large.jpg",
+        medium: "https://images.pexels.com/photos/12345/medium.jpg",
+      },
+      alt: "A model in monotone outfit",
+    },
+  ],
+});
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  vi.stubEnv("PEXELS_API_KEY", MOCK_ACCESS_KEY);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("searchPexelsPhotos — URL / ヘッダ", () => {
+  it("Pexels v1/search エンドポイントを叩く", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makePexelsApiResponse()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchPexelsPhotos({ query: "denim", page: 1, perPage: 30 });
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain("https://api.pexels.com/v1/search");
+  });
+
+  it("query / page / per_page が URL に含まれる", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makePexelsApiResponse()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchPexelsPhotos({ query: "denim", page: 3, perPage: 20 });
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain("query=");
+    expect(calledUrl).toContain("page=3");
+    expect(calledUrl).toContain("per_page=20");
+  });
+
+  it("query に fashion 系のサフィックスが付与される（検索精度補強）", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makePexelsApiResponse()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchPexelsPhotos({ query: "denim", page: 1, perPage: 30 });
+
+    const calledUrl: string = fetchMock.mock.calls[0][0];
+    const decoded = decodeURIComponent(calledUrl.replace(/\+/g, " "));
+    expect(decoded.toLowerCase()).toContain("fashion");
+  });
+
+  it("Authorization ヘッダに API キーを直接設定する（Bearer 無し）", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makePexelsApiResponse()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchPexelsPhotos({ query: "denim", page: 1, perPage: 30 });
+
+    const calledOptions: RequestInit = fetchMock.mock.calls[0][1];
+    const headers = calledOptions.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(MOCK_ACCESS_KEY);
+  });
+});
+
+describe("searchPexelsPhotos — 成功時", () => {
+  it("photos 配列と totalPages を返す", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify(
+            makePexelsApiResponse({ total_results: 60, per_page: 30 }),
+          ),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchPexelsPhotos({
+      query: "denim",
+      page: 1,
+      perPage: 30,
+    });
+
+    expect(result.photos).toHaveLength(1);
+    // total_results 60 / per_page 30 → 2 ページ
+    expect(result.totalPages).toBe(2);
+  });
+
+  it("photos の各要素に id / src.large / photographer が含まれる", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(makePexelsApiResponse()), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchPexelsPhotos({
+      query: "denim",
+      page: 1,
+      perPage: 30,
+    });
+
+    const photo = result.photos[0];
+    expect(photo).toHaveProperty("id");
+    expect(photo.src).toHaveProperty("large");
+    expect(photo).toHaveProperty("photographer");
+  });
+});
+
+describe("searchPexelsPhotos — フォールバック（throws しない）", () => {
+  it("PEXELS_API_KEY 未設定なら fetch を叩かず空結果を返す", async () => {
+    vi.unstubAllEnvs();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchPexelsPhotos({
+      query: "denim",
+      page: 1,
+      perPage: 30,
+    });
+
+    expect(result).toEqual({ photos: [], totalPages: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("HTTP 401/403/429/500 はすべて空結果を返す", async () => {
+    for (const status of [401, 403, 429, 500]) {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response("err", { status }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await searchPexelsPhotos({
+        query: "denim",
+        page: 1,
+        perPage: 30,
+      });
+
+      expect(result).toEqual({ photos: [], totalPages: 0 });
+    }
+  });
+
+  it("fetch が reject したとき空結果を返す（throws しない）", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchPexelsPhotos({
+      query: "denim",
+      page: 1,
+      perPage: 30,
+    });
+
+    expect(result).toEqual({ photos: [], totalPages: 0 });
+  });
+
+  it("レスポンスの photos が想定形式と異なる要素を含むとき、その要素はスキップされる", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify(
+          makePexelsApiResponse({
+            photos: [
+              // 有効
+              {
+                id: 1,
+                width: 100,
+                height: 100,
+                url: "https://www.pexels.com/photo/1/",
+                photographer: "A",
+                photographer_url: "https://www.pexels.com/@a",
+                photographer_id: 1,
+                src: {
+                  original: "https://images.pexels.com/photos/1/orig.jpg",
+                  large: "https://images.pexels.com/photos/1/large.jpg",
+                  medium: "https://images.pexels.com/photos/1/medium.jpg",
+                },
+                alt: "ok",
+              },
+              // 不正 (src 欠落)
+              { id: 2, photographer: "B" },
+            ],
+          }),
+        ),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchPexelsPhotos({
+      query: "denim",
+      page: 1,
+      perPage: 30,
+    });
+
+    expect(result.photos).toHaveLength(1);
+    expect(result.photos[0].id).toBe(1);
+  });
+
+  it("レスポンスが JSON として壊れているとき空結果を返す", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("not json", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchPexelsPhotos({
+      query: "denim",
+      page: 1,
+      perPage: 30,
+    });
+
+    expect(result).toEqual({ photos: [], totalPages: 0 });
+  });
+});

--- a/types/snap.ts
+++ b/types/snap.ts
@@ -12,9 +12,16 @@ import { COLOR_CATEGORIES } from "@/lib/color-catalog";
 // 同じ enum を共有し、16 系統以外の値が DB / API 経由で混入するのを防ぐ。
 const ColorCategoryEnum = z.enum(COLOR_CATEGORIES);
 
+// 着こなし検索で取得元として使うサービス。
+// "pexels" は UI 上は "Pinterest" と表示する（ブランディング都合）が、
+// 内部実装・DB・型はすべて "pexels" で統一する。
+export const SNAP_SOURCES = ["unsplash", "pexels"] as const;
+export const SnapSourceEnum = z.enum(SNAP_SOURCES);
+export type SnapSource = z.infer<typeof SnapSourceEnum>;
+
 export const SnapSchema = z.object({
   id: z.string().uuid(),
-  source: z.string().min(1),
+  source: SnapSourceEnum,
   externalId: z.string().min(1),
   imageUrl: z.string().min(1),
   sourceUrl: z.string().min(1),
@@ -47,6 +54,7 @@ export const SnapSummarySchema = SnapSchema.pick({
   imageUrl: true,
   authorName: true,
   sourceUrl: true,
+  source: true,
 });
 export type SnapSummary = z.infer<typeof SnapSummarySchema>;
 


### PR DESCRIPTION
## Summary

- 着こなし検索（\`/search\`）を **Unsplash + Pexels の 2 ソース並列** に拡張
- Pexels は Pinterest 公式 API がサービスアカウント検索を提供していないため代替として採用。UI 上は "Pinterest" バッジで表示
- 検索結果は混在グリッドで、各 \`SnapCard\` の左上にソースバッジを表示
- 既存 Unsplash 単独経路のテスト（search.test.ts / search.filter.test.ts 計 38 件）は無回帰

## バックエンド

- \`services/pexels-service.ts\` 新規。Zod で envelope と各 photo を検証、すべての失敗パスで \`{ photos: [], totalPages: 0 }\` 返却（並列検索で片方失敗を吸収）
- \`services/snap-service.ts\` の upsert を generic 化し \`upsertPexelsSnaps\` を新設。Unsplash / Pexels を共通の \`ExternalPhoto\` 経由でハンドリング
- \`app/actions/search.ts\` に \`fetchAndCacheFromSources\` を追加し \`Promise.allSettled\` で並列取得

## 型

- \`types/snap.ts\` に \`SnapSourceEnum\` / \`SNAP_SOURCES\` を追加
- \`SnapSchema.source\` を \`z.enum\` 化（既存テストの \`"unsplash"\` は valid のまま）
- \`SnapSummary\` に \`source\` を追加（バッジ表示用）

## 設定

- \`.env.example\` に \`PEXELS_API_KEY\` を追加
- \`lib/image-hosts.ts\` / \`next.config.ts\` に \`images.pexels.com\` を追加

## UI

- \`SnapCard\` 左上にソースバッジ。\`source === "pexels"\` → "Pinterest"、\`"unsplash"\` → "Unsplash" 表示
- バッジは画像の上に半透明 denim-dark 背景で重ねる（fashion 画像の主役を妨げない）

## Test plan

- [x] \`npm run lint\` — PASS
- [x] \`npm run typecheck\` — PASS
- [x] \`npm run build\` — PASS
- [x] \`npm test -- --run\` — PASS 583/583（+13 ケース: Pexels 11 + SnapCard バッジ 2）
- [ ] Vercel Preview で \`PEXELS_API_KEY\` を環境変数に設定し検索結果に Pexels 写真が混在することを確認
- [ ] \`PEXELS_API_KEY\` 未設定でも Unsplash 単独動作することを確認
- [ ] 検索結果カードに "Pinterest" / "Unsplash" バッジが正しく表示されることを確認

## 補足

- 内部実装・DB・型はすべて \`"pexels"\`、UI 表示のみ \`"Pinterest"\` 固定（マップは \`SnapCard\` 内に閉じる）
- Pexels API レート: 200 req/hour, 20000/month。本番でも当面は十分

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Pexelsを第二のイメージソースに統合
  * 複数ソースから並列検索で結果を拡充
  * 画像カードにソースバッジを表示

* **Refactor**
  * 検索ロジックを複数ソース対応に統合

* **Tests**
  * Pexels検索とソース表示のテストを追加

* **Chores**
  * 環境設定とイメージホスト許可リストを更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fune6900/DIG/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->