### PR TITLE
Showcase: pick random snaps from DB cache (Unsplash rate limit fix)

### DIFF
--- a/app/(public)/_components/landing/ShowcaseSection.tsx
+++ b/app/(public)/_components/landing/ShowcaseSection.tsx
@@ -40,7 +40,12 @@ const SHOWCASE_TILES = [
 ] as const;
 
 export async function ShowcaseSection() {
-  const snaps = await findRandomSnaps(SHOWCASE_TILES.length).catch(() => []);
+  const snaps = await findRandomSnaps(SHOWCASE_TILES.length).catch(
+    (err: unknown) => {
+      console.error("[ShowcaseSection] findRandomSnaps failed", err);
+      return [];
+    },
+  );
 
   return (
     <section className="relative overflow-hidden bg-offwhite-subtle px-6 py-24 dark:bg-canvas-subtle sm:py-32">

--- a/app/(public)/_components/landing/ShowcaseSection.tsx
+++ b/app/(public)/_components/landing/ShowcaseSection.tsx
@@ -1,61 +1,46 @@
 import Image from "next/image";
 import { FadeIn, StaggerChildren, StaggerItem } from "@/components/ui/motion";
-import {
-  fetchRandomUnsplashPhoto,
-  type UnsplashPhoto,
-} from "@/services/unsplash-service";
+import { findRandomSnaps } from "@/services/snap-service";
 
-// Showcase はトップ LP のギャラリー帯。各タイルのテーマで Unsplash の
-// /photos/random を叩き、毎リクエスト別画像を表示する。API キー未設定や
-// 失敗時は CSS グラデーションのプレースホルダにフォールバックする。
+// Showcase はトップ LP のギャラリー帯。着こなし検索で DB にキャッシュ済みの
+// Snap（Unsplash / Pexels）から ORDER BY RANDOM() で 6 件ピックして表示する。
+// API キー rate limit に依存せず、毎リクエスト別画像を出せる。DB が空のとき
+// は CSS グラデーションのプレースホルダにフォールバックする。
 const SHOWCASE_TILES = [
   {
     mood: "MINIMAL",
     style: "Monotone",
-    query: "minimalist fashion monochrome",
     grad: "from-denim-dark via-denim to-denim-light",
   },
   {
     mood: "STATEMENT",
     style: "Color",
-    query: "colorful bold outfit",
     grad: "from-canvas via-denim-dark to-rust",
   },
   {
     mood: "DAILY",
     style: "Casual",
-    query: "casual everyday fashion",
     grad: "from-denim to-canvas",
   },
   {
     mood: "LAYER",
     style: "Layering",
-    query: "layered outfit fashion",
     grad: "from-denim-light via-offwhite-subtle to-denim",
   },
   {
     mood: "EARTH",
     style: "Outdoor",
-    query: "outdoor earth tone fashion",
     grad: "from-rust via-rust-light to-offwhite-subtle",
   },
   {
     mood: "STREET",
     style: "Edge",
-    query: "street style edgy fashion",
     grad: "from-canvas-subtle via-denim to-denim-light",
   },
 ] as const;
 
-function buildAlt(photo: UnsplashPhoto, fallback: string): string {
-  const subject = photo.alt_description?.trim() || fallback;
-  return `${subject} — Photo by ${photo.user.name} on Unsplash`;
-}
-
 export async function ShowcaseSection() {
-  const photos = await Promise.all(
-    SHOWCASE_TILES.map((tile) => fetchRandomUnsplashPhoto(tile.query)),
-  );
+  const snaps = await findRandomSnaps(SHOWCASE_TILES.length).catch(() => []);
 
   return (
     <section className="relative overflow-hidden bg-offwhite-subtle px-6 py-24 dark:bg-canvas-subtle sm:py-32">
@@ -85,17 +70,20 @@ export async function ShowcaseSection() {
           stagger={0.08}
         >
           {SHOWCASE_TILES.map((tile, idx) => {
-            const photo = photos[idx];
+            const snap = snaps[idx];
+            const alt = snap?.authorName
+              ? `${snap.authorName} の ${tile.style}`
+              : `${tile.style} fashion`;
             return (
               <StaggerItem
                 key={`${tile.mood}-${tile.style}-${idx}`}
                 as="li"
                 className="group relative aspect-[3/4] overflow-hidden border border-denim/10 dark:border-offwhite/10"
               >
-                {photo ? (
+                {snap ? (
                   <Image
-                    src={photo.urls.regular}
-                    alt={buildAlt(photo, `${tile.style} fashion`)}
+                    src={snap.imageUrl}
+                    alt={alt}
                     fill
                     sizes="(max-width: 640px) 50vw, 33vw"
                     className="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.04]"

--- a/services/snap-service.ts
+++ b/services/snap-service.ts
@@ -98,6 +98,33 @@ export async function updateSnap(
   return prisma.snap.update({ where: { id }, data }) as Promise<Snap>;
 }
 
+/**
+ * Snap テーブルから ORDER BY RANDOM() で limit 件をランダム抽出する。
+ * LP の Showcase で使用し、Unsplash の rate limit に依存せず「毎回別画像」
+ * 要件を満たす。limit は 50 で clamp する。
+ */
+export async function findRandomSnaps(limit: number): Promise<SnapSummary[]> {
+  const safeLimit = Math.min(Math.floor(limit), 50);
+  if (safeLimit <= 0) return [];
+
+  const rows = await prisma.$queryRaw<
+    Array<{
+      id: string;
+      imageUrl: string;
+      authorName: string | null;
+      sourceUrl: string;
+      source: string;
+    }>
+  >`
+    SELECT id, "imageUrl", "authorName", "sourceUrl", source
+    FROM "Snap"
+    ORDER BY RANDOM()
+    LIMIT ${safeLimit}
+  `;
+
+  return rows.map(normalizeSummary);
+}
+
 export async function findSimilarSnaps(params: {
   snapId: string;
   searchQueries: string[];

--- a/services/snap-service.ts
+++ b/services/snap-service.ts
@@ -1,3 +1,4 @@
+import { unstable_noStore as noStore } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import {
@@ -101,11 +102,15 @@ export async function updateSnap(
 /**
  * Snap テーブルから ORDER BY RANDOM() で limit 件をランダム抽出する。
  * LP の Showcase で使用し、Unsplash の rate limit に依存せず「毎回別画像」
- * 要件を満たす。limit は 50 で clamp する。
+ * 要件を満たす。limit は 50 で clamp する（DoS 防御）。
+ *
+ * noStore() で本関数を呼ぶ route を dynamic 化する。これを呼ばないと Next.js
+ * のデフォルトで `/` が静的化され、ビルド時の 1 回しか抽出されなくなる。
  */
 export async function findRandomSnaps(limit: number): Promise<SnapSummary[]> {
+  noStore();
   const safeLimit = Math.min(Math.floor(limit), 50);
-  if (safeLimit <= 0) return [];
+  if (!Number.isFinite(safeLimit) || safeLimit <= 0) return [];
 
   const rows = await prisma.$queryRaw<
     Array<{

--- a/tests/unit/services/snap-service.test.ts
+++ b/tests/unit/services/snap-service.test.ts
@@ -14,11 +14,16 @@ vi.mock("@/lib/prisma", () => ({
       createMany: vi.fn(),
       update: vi.fn(),
     },
+    $queryRaw: vi.fn(),
   },
 }));
 
 import { prisma } from "@/lib/prisma";
-import { findSnapsByQuery, upsertSnaps } from "@/services/snap-service";
+import {
+  findRandomSnaps,
+  findSnapsByQuery,
+  upsertSnaps,
+} from "@/services/snap-service";
 import type { UnsplashPhoto } from "@/services/unsplash-service";
 
 // ---------------------------------------------------------------------------
@@ -307,5 +312,97 @@ describe("upsertSnaps", () => {
         },
       }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findRandomSnaps（LP Showcase 用に DB から random ピック）
+// ---------------------------------------------------------------------------
+describe("findRandomSnaps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("limit=0 のとき DB を叩かず空配列を返す", async () => {
+    const result = await findRandomSnaps(0);
+    expect(result).toEqual([]);
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("正常系: $queryRaw の戻りを SnapSummary[] にマッピングする", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([
+      {
+        id: "snap-uuid-1",
+        imageUrl: "https://images.unsplash.com/photo-1/regular",
+        authorName: "John Doe",
+        sourceUrl: "https://unsplash.com/photos/photo-1",
+        source: "unsplash",
+      },
+      {
+        id: "snap-uuid-2",
+        imageUrl: "https://images.pexels.com/photos/2/large.jpg",
+        authorName: "Jane Photographer",
+        sourceUrl: "https://www.pexels.com/photo/2/",
+        source: "pexels",
+      },
+    ] as unknown as never);
+
+    const result = await findRandomSnaps(6);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: "snap-uuid-1",
+      imageUrl: "https://images.unsplash.com/photo-1/regular",
+      authorName: "John Doe",
+      sourceUrl: "https://unsplash.com/photos/photo-1",
+      source: "unsplash",
+    });
+    expect(result[1].source).toBe("pexels");
+  });
+
+  it("未知の source は 'unsplash' に正規化される（前方互換）", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([
+      {
+        id: "snap-uuid-3",
+        imageUrl: "https://images.unsplash.com/photo-3/regular",
+        authorName: null,
+        sourceUrl: "https://unsplash.com/photos/photo-3",
+        source: "future-source",
+      },
+    ] as unknown as never);
+
+    const result = await findRandomSnaps(1);
+
+    expect(result[0].source).toBe("unsplash");
+  });
+
+  it("limit は 50 で clamp される（DoS 防御）", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([] as unknown as never);
+
+    await findRandomSnaps(9999);
+
+    // template literal 第二引数 (values) に 50 が渡されること
+    const call = vi.mocked(prisma.$queryRaw).mock.calls[0];
+    expect(call).toBeDefined();
+    // Prisma の tagged template だと call[0]=strings, call[1...]=values
+    // 第 2 引数（最初のパラメータ）が clamp 後の 50 であること
+    expect(call[1]).toBe(50);
+  });
+
+  it("小数 limit は Math.floor される", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([] as unknown as never);
+
+    await findRandomSnaps(3.7);
+
+    const call = vi.mocked(prisma.$queryRaw).mock.calls[0];
+    expect(call[1]).toBe(3);
+  });
+
+  it("$queryRaw が空配列を返したとき空配列を返す", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([] as unknown as never);
+
+    const result = await findRandomSnaps(6);
+
+    expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

PR #74 で導入した Unsplash \`/photos/random\` の直叩きは、Demo クライアントの **rate limit 50 req/hour** を Showcase の 6 並列 fetch でリロード数回で枯渇させ、本番 / 開発ともに 403 "Rate Limit Exceeded" → グラデフォールバックばかりになっていた。

着こなし検索で既に Snap テーブルにキャッシュされた Unsplash / Pexels 写真を \`ORDER BY RANDOM()\` で 6 件ピックして表示するよう変更。rate limit に依存せず「毎リクエスト別画像」要件を維持。

## Changes

- \`services/snap-service.ts\` に \`findRandomSnaps(limit)\` を追加。Prisma \`$queryRaw\` で \`ORDER BY RANDOM() LIMIT\` を発行
  - \`limit\` は 50 で clamp、\`Math.floor\` で小数も正規化（DoS 防御）
  - 結果は既存 \`normalizeSummary\` で \`SnapSummary[]\`（source enum 含む）に整形
- \`ShowcaseSection\` を \`findRandomSnaps(6)\` ベースに書き換え
  - \`fetchRandomUnsplashPhoto\` を呼ばない
  - \`snaps[idx]\` があれば \`next/image\` で表示、不足分は既存グラデ fallback
- \`fetchRandomUnsplashPhoto\` は Showcase から不参照になるが、関数自体は既存テストと将来再利用のため残置
- \`snap-service.test.ts\` に \`$queryRaw\` mock を追加、\`findRandomSnaps\` 6 ケースのテスト

## Test plan

- [x] \`npm run lint\` — PASS
- [x] \`npm run typecheck\` — PASS
- [x] \`npm run build\` — PASS
- [x] \`npm test -- --run\` — PASS 589/589（+6 ケース）
- [x] ローカル dev で 6 タイル全部画像表示確認（Unsplash 5 + Pexels 1 が混在で random pick された）

## 補足

- Snap が 0 件の fresh DB ではタイル全部グラデ fallback → 既存挙動と互換
- 毎リクエスト DB クエリで pick するので「毎回別画像」要件は維持
- 本番では Vercel 環境変数 \`UNSPLASH_ACCESS_KEY\` / \`PEXELS_API_KEY\` 設定済みで着こなし検索 → Snap が貯まれば Showcase でも順次表示される

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ショーケースセクションの画像取得機能を改善し、より安定した画像表示を実現しました。

* **Bug Fixes**
  * 画像取得失敗時のフォールバック処理を強化しました。

* **Tests**
  * 新しい画像取得機能の単体テストを追加し、限度値の制御、エラーハンドリング、データ正規化を検証しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fune6900/DIG/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->